### PR TITLE
Refactors dispensing dashboard to use extensions for reuse

### DIFF
--- a/src/dashboard/dispensing-dashboard.component.tsx
+++ b/src/dashboard/dispensing-dashboard.component.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import DispensingTiles from "../dispensing-tiles/dispensing-tiles.component";
+import Overlay from "../forms/overlay/overlay.component";
+import { PharmacyHeader } from "../pharmacy-header/pharmacy-header.component";
+import PrescriptionTabLists from "../prescriptions/prescription-tab-lists.component";
+
+export default function DispensingDashboard() {
+  return (
+    <div className={`omrs-main-content`}>
+      <PharmacyHeader />
+      {/* <DispensingTiles /> */}
+      <PrescriptionTabLists />
+      <Overlay />
+    </div>
+  );
+}

--- a/src/dispensing.component.tsx
+++ b/src/dispensing.component.tsx
@@ -1,16 +1,6 @@
 import React from "react";
-import { PharmacyHeader } from "./pharmacy-header/pharmacy-header.component";
-import DispensingTiles from "./dispensing-tiles/dispensing-tiles.component";
-import PrescriptionTabLists from "./prescriptions/prescription-tab-lists.component";
-import Overlay from "./forms/overlay/overlay.component";
+import { ExtensionSlot } from "@openmrs/esm-framework";
 
 export default function Dispensing() {
-  return (
-    <div className={`omrs-main-content`}>
-      <PharmacyHeader />
-      {/*      <DispensingTiles />*/}
-      <PrescriptionTabLists />
-      <Overlay />
-    </div>
-  );
+  return <ExtensionSlot name="dispensing-dashboard-slot" />;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,16 @@ function setupOpenMRS() {
         online: true,
         offline: false,
       },
+      {
+        name: "dispensing-dashboard",
+        slot: "dispensing-dashboard-slot",
+        load: getAsyncLifecycle(
+          () => import("./dashboard/dispensing-dashboard.component"),
+          options
+        ),
+        online: true,
+        offline: true,
+      },
     ],
   };
 }

--- a/src/prescriptions/prescription-tab-lists.component.tsx
+++ b/src/prescriptions/prescription-tab-lists.component.tsx
@@ -12,15 +12,23 @@ enum TabTypes {
   ALL,
 }
 
-const tabs = [
-  { label: "activePrescriptions", status: "ACTIVE" },
-  { label: "allPrescriptions", status: "" },
-];
-
 const PrescriptionTabLists: React.FC = () => {
   const { t } = useTranslation();
   const [selectedTab, setSelectedTab] = useState(TabTypes.STARRED);
   const [searchTerm, setSearchTerm] = useState("");
+
+  const tabs = [
+    {
+      key: "activePrescriptions",
+      header: t("activePrescriptions", "Active Prescriptions"),
+      status: "ACTIVE",
+    },
+    {
+      key: "allPrescriptions",
+      header: t("allPrescriptions", "All Prescriptions"),
+      status: "",
+    },
+  ];
 
   return (
     <main className={`omrs-main-content ${styles.prescriptionListContainer}`}>
@@ -39,12 +47,12 @@ const PrescriptionTabLists: React.FC = () => {
             {tabs.map((tab, index) => {
               return (
                 <Tab
-                  title={t(tab.label)}
+                  title={t(tab.key)}
                   key={index}
                   id={"tab-" + index}
                   className={styles.tab}
                 >
-                  {t(tab.label)}
+                  {t(tab.header)}
                 </Tab>
               );
             })}

--- a/src/prescriptions/prescriptions.scss
+++ b/src/prescriptions/prescriptions.scss
@@ -51,6 +51,10 @@ title {
   :global(.cds--tabs__nav-item--selected) {
     box-shadow: inset 0 2px 0 0 var(--brand-03) !important;
   }
+
+  :global(.cds--tab--list) button {
+    max-width: 12rem !important;
+  }
 }
 
 .hiddenTabsContent, .tabs .hiddenTabsContent {


### PR DESCRIPTION
- Refactors dispensing dashboard to use extensions for reuse 
- Changes to dashboard tabs to show full text labels

<img width="611" alt="Screenshot 2022-12-06 at 18 54 32" src="https://user-images.githubusercontent.com/15266028/205959838-25428c62-7916-4056-92fc-fee1a916ec06.png">
