### PR TITLE
O3-1663:Remove Delete prescription button from prescription details

### DIFF
--- a/src/components/prescription-expanded.component.tsx
+++ b/src/components/prescription-expanded.component.tsx
@@ -70,13 +70,6 @@ const PrescriptionExpanded: React.FC<{
       </div>
       <div className={styles.prescriptionActions}>
         <Button
-          kind="ghost"
-          renderIcon={() => <TrashCan />}
-          className={styles.deletePrescriptionBtn}
-        >
-          {t("deletePrescription", "Delete prescription")}
-        </Button>
-        <Button
           kind="primary"
           className={styles.dispenseBtn}
           onClick={() =>


### PR DESCRIPTION
**Description of what I changed**
I removed `Delete prescription button` from prescription details so that the Pharmacists can delete a dispensed medication event using the 3 dots on the even. 

**Issue worked on:**
https://issues.openmrs.org/browse/O3-1663

Video of the output after implementing the changes:

https://user-images.githubusercontent.com/33891016/207660653-dae3d108-7880-4251-b0cd-91c28a3b9e37.mp4




