### PR TITLE
O3-1608: Set "Reason for Change" when substituting drugs

### DIFF
--- a/src/components/medication-dispense-review.component.tsx
+++ b/src/components/medication-dispense-review.component.tsx
@@ -167,8 +167,8 @@ const MedicationDispenseReview: React.FC<MedicationDispenseReviewProps> = ({
   // get the medication request associated with this dispense event
   // (we fetch this so that we can use it below to determine if the formulation dispensed varies from what was
   // ordered; it's slightly inefficient/awkward to fetch it from the server here because we *have* fetched it earlier,
-  // it just seems cleaner to fetch it here rather than to make sure we pass it down through various components; and
-  // SWR should handle caching properly)
+  // it just seems cleaner to fetch it here rather than to make sure we pass it down through various components; with
+  // SWR handling caching, we may want to consider pulling more down into this)
   const { medicationRequest } = useMedicationRequest(
     medicationDispense.authorizingPrescription
       ? medicationDispense.authorizingPrescription[0].reference

--- a/src/components/medication-dispense-review.scss
+++ b/src/components/medication-dispense-review.scss
@@ -20,6 +20,14 @@
   gap: spacing.$spacing-05;
 }
 
+.substitutionReason {
+  width:100%;
+}
+
+.substitutionType {
+  width: 100%;
+}
+
 .productiveHeading02 {
   color: $color-gray-70;
   @include type.type-style('productive-heading-02');

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -25,8 +25,30 @@ export const configSchema = {
     _type: Type.String,
     _default: "Pharmacy",
   },
+  substitutionReason: {
+    uuid: {
+      _type: Type.UUID,
+      _description:
+        "UUID for the Value Set of valid answers to the 'Reason for Substitution' question",
+      _default: "",
+    },
+  },
+  substitutionType: {
+    uuid: {
+      _type: Type.UUID,
+      _description:
+        "UUID for the Value Set of valid answers to the 'Type of Substitution' question",
+      _default: "",
+    },
+  },
 };
 
 export type PharmacyConfig = {
-  appName: String;
+  appName: string;
+  substitutionReason: {
+    uuid: string;
+  };
+  substitutionType: {
+    uuid: string;
+  };
 };

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -29,7 +29,7 @@ export const configSchema = {
     uuid: {
       _type: Type.UUID,
       _description:
-        "UUID for the Value Set of valid answers to the 'Reason for Substitution' question",
+        "UUID for the Value Set of valid answers to the 'Reason for Substitution' question. Sample CIEL concept: https://app.openconceptlab.org/#/orgs/CIEL/sources/CIEL/concepts/167862/",
       _default: "",
     },
   },
@@ -37,7 +37,7 @@ export const configSchema = {
     uuid: {
       _type: Type.UUID,
       _description:
-        "UUID for the Value Set of valid answers to the 'Type of Substitution' question",
+        "UUID for the Value Set of valid answers to the 'Type of Substitution' question. Sample CIEL concept: https://app.openconceptlab.org/#/orgs/CIEL/sources/CIEL/concepts/167859/",
       _default: "",
     },
   },

--- a/src/forms/dispense-form.component.tsx
+++ b/src/forms/dispense-form.component.tsx
@@ -4,19 +4,12 @@ import {
   showToast,
   showNotification,
   useLayoutType,
-  useConfig,
 } from "@openmrs/esm-framework";
 import { Button, FormLabel, DataTableSkeleton } from "@carbon/react";
 import styles from "./dispense-form.scss";
 import { closeOverlay } from "../hooks/useOverlay";
 import { MedicationDispense } from "../types";
-import {
-  saveMedicationDispense,
-  useOrderConfig,
-  useSubstitutionReasonValueSet,
-  useSubstitutionTypeValueSet,
-} from "../medication-dispense/medication-dispense.resource";
-import { PharmacyConfig } from "../config-schema";
+import { saveMedicationDispense } from "../medication-dispense/medication-dispense.resource";
 import MedicationDispenseReview from "../components/medication-dispense-review.component";
 
 interface DispenseFormProps {
@@ -34,32 +27,11 @@ const DispenseForm: React.FC<DispenseFormProps> = ({
 }) => {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === "tablet";
-  const config = useConfig() as PharmacyConfig;
-  const { orderConfigObject } = useOrderConfig();
-  const { substitutionTypeValueSet } = useSubstitutionTypeValueSet(
-    config.substitutionType.uuid
-  );
-  const { substitutionReasonValueSet } = useSubstitutionReasonValueSet(
-    config.substitutionReason.uuid
-  );
 
   // Keep track of medication dispense payload
   const [medicationDispensesPayload, setMedicationDispensesPayload] = useState(
     []
   );
-
-  // Dosing Unit eg Tablets
-  const [drugDosingUnits, setDrugDosingUnits] = useState([]);
-  // Dispensing Unit eg Tablets
-  const [drugDispensingUnits, setDrugDispensingUnits] = useState([]);
-  // Route eg Oral
-  const [drugRoutes, setDrugRoutes] = useState([]);
-  // Frequency eg Twice daily
-  const [orderFrequencies, setOrderFrequencies] = useState([]);
-  // type of substitution question
-  const [substitutionTypes, setSubstitutionTypes] = useState([]);
-  // reason for substitution question
-  const [substitutionReasons, setSubstitutionReasons] = useState([]);
 
   // whether or note the form is valid and ready to submit
   const [isValid, setIsValid] = useState(false);
@@ -164,89 +136,6 @@ const DispenseForm: React.FC<DispenseFormProps> = ({
 
   useEffect(checkIsValid, [medicationDispensesPayload]);
 
-  useEffect(() => {
-    if (orderConfigObject) {
-      // sync drug route options order config
-      const availableRoutes = drugRoutes.map((x) => x.id);
-      const otherRouteOptions = [];
-      orderConfigObject.drugRoutes.forEach(
-        (x) =>
-          availableRoutes.includes(x.uuid) ||
-          otherRouteOptions.push({ id: x.uuid, text: x.display })
-      );
-      setDrugRoutes([...drugRoutes, ...otherRouteOptions]);
-
-      // sync dosage.unit options with what's defined in the order config
-      const availableDosingUnits = drugDosingUnits.map((x) => x.id);
-      const otherDosingUnits = [];
-      orderConfigObject.drugDosingUnits.forEach(
-        (x) =>
-          availableDosingUnits.includes(x.uuid) ||
-          otherDosingUnits.push({ id: x.uuid, text: x.display })
-      );
-      setDrugDosingUnits([...drugDosingUnits, ...otherDosingUnits]);
-
-      // sync dispensing unit options with what's defined in the order config
-      const availableDispensingUnits = drugDispensingUnits.map((x) => x.id);
-      const otherDispensingUnits = [];
-      orderConfigObject.drugDispensingUnits.forEach(
-        (x) =>
-          availableDispensingUnits.includes(x.uuid) ||
-          otherDispensingUnits.push({ id: x.uuid, text: x.display })
-      );
-      setDrugDispensingUnits([...drugDispensingUnits, ...otherDispensingUnits]);
-
-      // sync order frequency options with order config
-      const availableFrequencies = orderFrequencies.map((x) => x.id);
-      const otherFrequencyOptions = [];
-      orderConfigObject.orderFrequencies.forEach(
-        (x) =>
-          availableFrequencies.includes(x.uuid) ||
-          otherFrequencyOptions.push({ id: x.uuid, text: x.display })
-      );
-      setOrderFrequencies([...orderFrequencies, ...otherFrequencyOptions]);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [orderConfigObject]);
-
-  useEffect(() => {
-    const substitutionTypeOptions = [];
-
-    if (substitutionTypeValueSet?.compose?.include) {
-      const uuidValueSet = substitutionTypeValueSet.compose.include.find(
-        (include) => !include.system
-      );
-      if (uuidValueSet) {
-        uuidValueSet.concept?.forEach((concept) =>
-          substitutionTypeOptions.push({
-            id: concept.code,
-            text: concept.display,
-          })
-        );
-      }
-    }
-    setSubstitutionTypes(substitutionTypeOptions);
-  }, [substitutionTypeValueSet]);
-
-  useEffect(() => {
-    const substitutionReasonOptions = [];
-
-    if (substitutionReasonValueSet?.compose?.include) {
-      const uuidValueSet = substitutionReasonValueSet.compose.include.find(
-        (include) => !include.system
-      );
-      if (uuidValueSet) {
-        uuidValueSet.concept?.forEach((concept) =>
-          substitutionReasonOptions.push({
-            id: concept.code,
-            text: concept.display,
-          })
-        );
-      }
-    }
-    setSubstitutionReasons(substitutionReasonOptions);
-  }, [substitutionReasonValueSet]);
-
   return (
     <div className="">
       {isLoading && <DataTableSkeleton role="progressbar" />}
@@ -266,12 +155,6 @@ const DispenseForm: React.FC<DispenseFormProps> = ({
                 medicationDispense={medicationDispense}
                 updateMedicationDispense={updateMedicationDispenseRequest}
                 index={index}
-                drugDosingUnits={drugDosingUnits}
-                drugDispensingUnits={drugDispensingUnits}
-                drugRoutes={drugRoutes}
-                orderFrequencies={orderFrequencies}
-                substitutionReasons={substitutionReasons}
-                substitutionTypes={substitutionTypes}
               />
             ))}
         </section>

--- a/src/medication-dispense/medication-dispense.resource.tsx
+++ b/src/medication-dispense/medication-dispense.resource.tsx
@@ -1,7 +1,12 @@
 import { fhirBaseUrl, openmrsFetch, Session } from "@openmrs/esm-framework";
 import dayjs from "dayjs";
 import useSWR from "swr";
-import { MedicationDispense, MedicationRequest, OrderConfig } from "../types";
+import {
+  MedicationDispense,
+  MedicationRequest,
+  OrderConfig,
+  ValueSet,
+} from "../types";
 
 export function saveMedicationDispense(
   medicationDispense: MedicationDispense,
@@ -43,6 +48,26 @@ export function useOrderConfig() {
     isLoading: !data && !error,
     isError: error,
     isValidating,
+  };
+}
+
+export function useSubstitutionTypeValueSet(uuid: string) {
+  const { data } = useSWR<{ data: ValueSet }, Error>(
+    `${fhirBaseUrl}/ValueSet/${uuid}`,
+    openmrsFetch
+  );
+  return {
+    substitutionTypeValueSet: data ? data.data : null,
+  };
+}
+
+export function useSubstitutionReasonValueSet(uuid: string) {
+  const { data } = useSWR<{ data: ValueSet }, Error>(
+    `${fhirBaseUrl}/ValueSet/${uuid}`,
+    openmrsFetch
+  );
+  return {
+    substitutionReasonValueSet: data ? data.data : null,
   };
 }
 
@@ -117,6 +142,12 @@ export function initiateMedicationDispenseBody(
         ],
         substitution: {
           wasSubstituted: false,
+          reason: [
+            {
+              coding: [{ code: null }],
+            },
+          ],
+          type: { coding: [{ code: null }] },
         },
       };
       dispenseBody.push(dispense);

--- a/src/medication-request/medication-request.resource.tsx
+++ b/src/medication-request/medication-request.resource.tsx
@@ -219,3 +219,21 @@ export function usePatientAllergies(patientUuid: string) {
     isLoading: !allergiesArray && !error,
   };
 }
+
+// supports passing just the uuid/code or the entire reference, ie either: "MedicationReference/123-abc" or "123-abc"
+// TODO: do we need a refresh interval?
+export function useMedicationRequest(reference: string) {
+  reference = reference
+    ? reference.startsWith("MedicationRequest")
+      ? reference
+      : `MedicationRequest/${reference}`
+    : null;
+
+  const { data } = useSWR<{ data: MedicationRequest }, Error>(
+    reference ? `${fhirBaseUrl}/${reference}` : null,
+    openmrsFetch
+  );
+  return {
+    medicationRequest: data ? data.data : null,
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,11 @@ export interface Attribute {
   value: string | number;
 }
 
+export interface CodeableConcept {
+  coding: Coding[];
+  text: string;
+}
+
 export interface Coding {
   system?: string;
   code: string;
@@ -242,21 +247,15 @@ export interface MedicationDispense {
     type: string;
     display: string;
   };
-  type: {
-    coding: [
-      Array<{
-        code: string;
-        display: string;
-      }>
-    ];
-    text: string;
-  };
+  type: CodeableConcept;
   quantity: Quantity;
   whenPrepared: string;
   whenHandedOver: string;
   dosageInstruction: Array<DosageInstruction>;
   substitution: {
     wasSubstituted: boolean;
+    reason: CodeableConcept[];
+    type: CodeableConcept;
   };
 }
 
@@ -382,4 +381,25 @@ export interface Quantity {
   unit: string;
   code: string;
   system: string;
+}
+
+export interface ValueSet {
+  id: string;
+  title: string;
+  status: string;
+  date: string;
+  description: string;
+  compose: {
+    include: [
+      {
+        system: string;
+        concept: [
+          {
+            code: string;
+            display: string;
+          }
+        ];
+      }
+    ];
+  };
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -63,6 +63,8 @@
   "searchPrescriptions": "Search prescriptions",
   "sendBackToPrescriber": "Send back to prescriber",
   "status": "Status",
+  "substitutionReason": "Reason for substitution",
+  "substitutionType": "Type of substitution",
   "tabletOverlay": "Tablet overlay",
   "tabList": "Tab List",
   "today": "Today",


### PR DESCRIPTION
Note that there is still a slight problem is that we can't "clear out" the change reasons when editing an existing dispense event, see:

https://talk.openmrs.org/t/setting-property-values-to-null-when-submitting-fhir-objects-via-fhir2-module/38471/3