### PR TITLE
(fix) O3-1492: Remove dangerous global selectors from stylesheets

### DIFF
--- a/src/components/patient-details.scss
+++ b/src/components/patient-details.scss
@@ -85,9 +85,6 @@
   color: $interactive-01;
 }
 
-:global(.cds--tooltip--definition .cds--tooltip__trigger) {
-  border-bottom: none;
-}
 
 .buttonCol {
   display: flex;


### PR DESCRIPTION
## Summary

This PR removes some global style rules or scopes them within a class so they're self-contained to the components they affect and don't pollute the global scope. In this case, the `.cds--tooltip--definition .cds--tooltip__trigger` override gets moved to `esm-core` in the Carbon style [overrides file](https://github.com/openmrs/openmrs-esm-core/pull/644/files).

## Related Issue

https://issues.openmrs.org/browse/O3-1492