### PR TITLE
(feat) O3-2054: Add Patient's Name and Identifier to the Dispense Pop-out Window

### DIFF
--- a/src/components/action-buttons.component.test.tsx
+++ b/src/components/action-buttons.component.test.tsx
@@ -5,6 +5,7 @@ import { MedicationRequest, MedicationRequestStatus } from "../types";
 import { useConfig } from "@openmrs/esm-framework";
 
 const mockedUseConfig = useConfig as jest.Mock;
+const mockPatientUuid = "f8f8728f-8f0c-4a4f-b7f6-72cf77138060";
 
 describe("Action Buttons Component tests", () => {
   const mockedMutate = jest.fn(() => "mocked mutate");
@@ -122,6 +123,7 @@ describe("Action Buttons Component tests", () => {
 
     const { getByText, container } = render(
       <ActionButtons
+        patientUuid={mockPatientUuid}
         medicationRequest={medicationRequest}
         associatedMedicationDispenses={[]}
         mutate={mockedMutate}
@@ -230,6 +232,7 @@ describe("Action Buttons Component tests", () => {
 
     const { queryByText, container } = render(
       <ActionButtons
+        patientUuid={mockPatientUuid}
         medicationRequest={medicationRequest}
         associatedMedicationDispenses={[]}
         mutate={mockedMutate}

--- a/src/components/action-buttons.component.tsx
+++ b/src/components/action-buttons.component.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Button } from "@carbon/react";
-import { useConfig, usePatient, useSession } from "@openmrs/esm-framework";
+import { useConfig, useSession } from "@openmrs/esm-framework";
 import styles from "./action-buttons.scss";
 import { useTranslation } from "react-i18next";
 import {
@@ -24,19 +24,16 @@ interface ActionButtonsProps {
   medicationRequest: MedicationRequest;
   associatedMedicationDispenses: Array<MedicationDispense>;
   mutate: Function;
-  patientUuid?: string;
 }
 
 const ActionButtons: React.FC<ActionButtonsProps> = ({
   medicationRequest,
   associatedMedicationDispenses,
   mutate,
-  patientUuid,
 }) => {
   const { t } = useTranslation();
   const config = useConfig() as PharmacyConfig;
   const session = useSession();
-  const { patient, isLoading } = usePatient(patientUuid);
   const mostRecentMedicationDispenseStatus: MedicationDispenseStatus =
     getMostRecentMedicationDispenseStatus(associatedMedicationDispenses);
   const medicationRequestStatus = computeMedicationRequestStatus(
@@ -58,20 +55,6 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
     medicationRequestStatus === MedicationRequestStatus.active &&
     mostRecentMedicationDispenseStatus !== MedicationDispenseStatus.declined;
 
-  const DesignName = () => {
-    const styles = { paddingLeft: "20px", color: "gray", fontWeight: 500 };
-
-    if (patient) {
-      return (
-        <span style={styles}>
-          {`${patient.name[0].given[0]} ${patient.name[0].family} — #${patient.identifier[0].value}`}
-        </span>
-      );
-    }
-
-    return <span style={styles}>--- --</span>;
-  };
-
   return (
     <div className={styles.actionBtns}>
       {dispensable ? (
@@ -79,10 +62,7 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
           kind="primary"
           onClick={() =>
             launchOverlay(
-              <>
-                {t("dispensePrescription", "Dispense prescription")}
-                <DesignName />
-              </>,
+              t("dispensePrescription", "Dispense prescription"),
               <DispenseForm
                 medicationDispense={initiateMedicationDispenseBody(
                   medicationRequest,

--- a/src/components/action-buttons.component.tsx
+++ b/src/components/action-buttons.component.tsx
@@ -24,12 +24,14 @@ interface ActionButtonsProps {
   medicationRequest: MedicationRequest;
   associatedMedicationDispenses: Array<MedicationDispense>;
   mutate: Function;
+  patientUuid: string;
 }
 
 const ActionButtons: React.FC<ActionButtonsProps> = ({
   medicationRequest,
   associatedMedicationDispenses,
   mutate,
+  patientUuid,
 }) => {
   const { t } = useTranslation();
   const config = useConfig() as PharmacyConfig;
@@ -64,6 +66,7 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
             launchOverlay(
               t("dispensePrescription", "Dispense prescription"),
               <DispenseForm
+                patientUuid={patientUuid}
                 medicationDispense={initiateMedicationDispenseBody(
                   medicationRequest,
                   session,

--- a/src/components/action-buttons.component.tsx
+++ b/src/components/action-buttons.component.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Button } from "@carbon/react";
-import { useConfig, useSession } from "@openmrs/esm-framework";
+import { useConfig, usePatient, useSession } from "@openmrs/esm-framework";
 import styles from "./action-buttons.scss";
 import { useTranslation } from "react-i18next";
 import {
@@ -24,16 +24,19 @@ interface ActionButtonsProps {
   medicationRequest: MedicationRequest;
   associatedMedicationDispenses: Array<MedicationDispense>;
   mutate: Function;
+  patientUuid?: string;
 }
 
 const ActionButtons: React.FC<ActionButtonsProps> = ({
   medicationRequest,
   associatedMedicationDispenses,
   mutate,
+  patientUuid,
 }) => {
   const { t } = useTranslation();
   const config = useConfig() as PharmacyConfig;
   const session = useSession();
+  const { patient, isLoading } = usePatient(patientUuid);
   const mostRecentMedicationDispenseStatus: MedicationDispenseStatus =
     getMostRecentMedicationDispenseStatus(associatedMedicationDispenses);
   const medicationRequestStatus = computeMedicationRequestStatus(
@@ -55,6 +58,20 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
     medicationRequestStatus === MedicationRequestStatus.active &&
     mostRecentMedicationDispenseStatus !== MedicationDispenseStatus.declined;
 
+  const DesignName = () => {
+    const styles = { paddingLeft: "20px", color: "gray", fontWeight: 500 };
+
+    if (patient) {
+      return (
+        <span style={styles}>
+          {`${patient.name[0].given[0]} ${patient.name[0].family} — #${patient.identifier[0].value}`}
+        </span>
+      );
+    }
+
+    return <span style={styles}>--- --</span>;
+  };
+
   return (
     <div className={styles.actionBtns}>
       {dispensable ? (
@@ -62,7 +79,10 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
           kind="primary"
           onClick={() =>
             launchOverlay(
-              t("dispensePrescription", "Dispense prescription"),
+              <>
+                {t("dispensePrescription", "Dispense prescription")}
+                <DesignName />
+              </>,
               <DispenseForm
                 medicationDispense={initiateMedicationDispenseBody(
                   medicationRequest,

--- a/src/forms/dispense-form.component.tsx
+++ b/src/forms/dispense-form.component.tsx
@@ -1,11 +1,13 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
+  ExtensionSlot,
   showNotification,
   showToast,
   useLayoutType,
+  usePatient,
 } from "@openmrs/esm-framework";
-import { Button, FormLabel } from "@carbon/react";
+import { Button, FormLabel, InlineLoading } from "@carbon/react";
 import styles from "./forms.scss";
 import { closeOverlay } from "../hooks/useOverlay";
 import { MedicationDispense, MedicationDispenseStatus } from "../types";
@@ -16,15 +18,18 @@ interface DispenseFormProps {
   medicationDispense: MedicationDispense;
   mutate: Function;
   mode: "enter" | "edit";
+  patientUuid?: string;
 }
 
 const DispenseForm: React.FC<DispenseFormProps> = ({
   medicationDispense,
   mutate,
   mode,
+  patientUuid,
 }) => {
   const { t } = useTranslation();
   const isTablet = useLayoutType() === "tablet";
+  const { patient, isLoading } = usePatient(patientUuid);
 
   // Keep track of medication dispense payload
   const [medicationDispensePayload, setMedicationDispensePayload] =
@@ -119,9 +124,33 @@ const DispenseForm: React.FC<DispenseFormProps> = ({
   // check is valid on any changes
   useEffect(checkIsValid, [medicationDispensePayload]);
 
+  const bannerState = useMemo(() => {
+    if (patient) {
+      return {
+        patient,
+        patientUuid,
+        hideActionsOverflow: true,
+      };
+    }
+  }, [patient, patientUuid]);
+
   return (
     <div className="">
       <div className={styles.formWrapper}>
+        {isLoading && (
+          <InlineLoading
+            className={styles.bannerLoading}
+            iconDescription="Loading"
+            description="Loading banner"
+            status="active"
+          />
+        )}
+        {patient && (
+          <ExtensionSlot
+            extensionSlotName="patient-header-slot"
+            state={bannerState}
+          />
+        )}
         <section className={styles.formGroup}>
           {/* <span style={{ marginTop: "1rem" }}>1. {t("drug", "Drug")}</span>*/}
           <FormLabel>

--- a/src/forms/forms.scss
+++ b/src/forms/forms.scss
@@ -37,6 +37,12 @@ $color-blue-30: #a6c8ff;
   @extend .productiveHeading02;
 }
 
+.bannerLoading {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
 .patientInfo {
   position: sticky;
   z-index: 1000;

--- a/src/hooks/useOverlay.tsx
+++ b/src/hooks/useOverlay.tsx
@@ -4,23 +4,16 @@ import { useEffect, useState } from "react";
 interface OverlayStore {
   isOverlayOpen: boolean;
   component?: any;
-  header: string | JSX.Element;
+  header: string;
 }
 
-const initialState: OverlayStore = {
-  isOverlayOpen: false,
-  component: Function,
-  header: "",
-};
+const initialState = { isOverlayOpen: false, component: Function, header: "" };
 
 const getOverlayStore = () => {
   return getGlobalStore("dispensing-store", initialState);
 };
 
-export const launchOverlay = (
-  headerTitle: string | JSX.Element,
-  componentToRender
-) => {
+export const launchOverlay = (headerTitle: string, componentToRender) => {
   const store = getOverlayStore();
   store.setState({
     isOverlayOpen: true,

--- a/src/hooks/useOverlay.tsx
+++ b/src/hooks/useOverlay.tsx
@@ -4,16 +4,23 @@ import { useEffect, useState } from "react";
 interface OverlayStore {
   isOverlayOpen: boolean;
   component?: any;
-  header: string;
+  header: string | JSX.Element;
 }
 
-const initialState = { isOverlayOpen: false, component: Function, header: "" };
+const initialState: OverlayStore = {
+  isOverlayOpen: false,
+  component: Function,
+  header: "",
+};
 
 const getOverlayStore = () => {
   return getGlobalStore("dispensing-store", initialState);
 };
 
-export const launchOverlay = (headerTitle: string, componentToRender) => {
+export const launchOverlay = (
+  headerTitle: string | JSX.Element,
+  componentToRender
+) => {
   const store = getOverlayStore();
   store.setState({
     isOverlayOpen: true,

--- a/src/prescriptions/prescription-details.component.tsx
+++ b/src/prescriptions/prescription-details.component.tsx
@@ -152,6 +152,7 @@ const PrescriptionDetails: React.FC<{
                 <ActionButtons
                   medicationRequest={request}
                   associatedMedicationDispenses={associatedMedicationDispenses}
+                  patientUuid={patientUuid}
                   mutate={() => {
                     mutate();
                     mutatePrescriptionDetails();

--- a/src/prescriptions/prescription-details.component.tsx
+++ b/src/prescriptions/prescription-details.component.tsx
@@ -152,7 +152,6 @@ const PrescriptionDetails: React.FC<{
                 <ActionButtons
                   medicationRequest={request}
                   associatedMedicationDispenses={associatedMedicationDispenses}
-                  patientUuid={patientUuid}
                   mutate={() => {
                     mutate();
                     mutatePrescriptionDetails();

--- a/src/prescriptions/prescription-details.component.tsx
+++ b/src/prescriptions/prescription-details.component.tsx
@@ -150,6 +150,7 @@ const PrescriptionDetails: React.FC<{
             <Tile className={styles.prescriptionTile}>
               <UserHasAccess privilege={PRIVILEGE_CREATE_DISPENSE}>
                 <ActionButtons
+                  patientUuid={patientUuid}
                   medicationRequest={request}
                   associatedMedicationDispenses={associatedMedicationDispenses}
                   mutate={() => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
- Adds patient banner to the Dispense Pop-out Window 

## Screenshots
![Screenshot from 2023-04-27 20-22-13](https://user-images.githubusercontent.com/104269786/235062699-5e84bed9-fbf5-488b-a2bf-fe23b907f14a.png)
reenshots
<!-- Required if you are making UI changes. -->

## Screencasts
[Screencast from 2023-04-28 08-28-25.webm](https://user-images.githubusercontent.com/104269786/235062732-12f0f093-3226-45a6-9b62-03c4d739d38c.webm)



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
- https://issues.openmrs.org/browse/O3-2054

## Other
<!-- Anything not covered above -->
