### PR TITLE
(fix) Remove deprecated `extensionSlotName` prop

### DIFF
--- a/src/components/patient-details.component.tsx
+++ b/src/components/patient-details.component.tsx
@@ -31,10 +31,7 @@ const PatientDetails: React.FC<{
 
   const patientAvatar = (
     <div className={styles.patientAvatar} role="img">
-      <ExtensionSlot
-        extensionSlotName="patient-photo-slot"
-        state={patientPhotoSlotState}
-      />
+      <ExtensionSlot name="patient-photo-slot" state={patientPhotoSlotState} />
     </div>
   );
 
@@ -70,7 +67,7 @@ const PatientDetails: React.FC<{
       {patient && (
         <div className={styles.patientDetailsContainer}>
           <ExtensionSlot
-            extensionSlotName="dispensing-patient-banner-slot"
+            name="dispensing-patient-banner-slot"
             state={{
               patient,
               patientUuid: patientUuid,
@@ -78,7 +75,7 @@ const PatientDetails: React.FC<{
           />
 
           <ExtensionSlot
-            extensionSlotName="dispensing-patient-vitals-slot"
+            name="dispensing-patient-vitals-slot"
             state={{
               patient,
               patientUuid: patientUuid,
@@ -86,7 +83,7 @@ const PatientDetails: React.FC<{
           />
 
           <ExtensionSlot
-            extensionSlotName="dispensing-patient-allergies-slot"
+            name="dispensing-patient-allergies-slot"
             state={{
               patient,
               patientUuid: patientUuid,

--- a/src/forms/close-dispense-form.component.tsx
+++ b/src/forms/close-dispense-form.component.tsx
@@ -184,10 +184,7 @@ const CloseDispenseForm: React.FC<CloseDispenseFormProps> = ({
           />
         )}
         {patient && (
-          <ExtensionSlot
-            extensionSlotName="patient-header-slot"
-            state={bannerState}
-          />
+          <ExtensionSlot name="patient-header-slot" state={bannerState} />
         )}
         <section className={styles.formGroup}>
           <ComboBox

--- a/src/forms/dispense-form.component.tsx
+++ b/src/forms/dispense-form.component.tsx
@@ -189,10 +189,7 @@ const DispenseForm: React.FC<DispenseFormProps> = ({
           />
         )}
         {patient && (
-          <ExtensionSlot
-            extensionSlotName="patient-header-slot"
-            state={bannerState}
-          />
+          <ExtensionSlot name="patient-header-slot" state={bannerState} />
         )}
         <section className={styles.formGroup}>
           {/* <span style={{ marginTop: "1rem" }}>1. {t("drug", "Drug")}</span>*/}

--- a/src/forms/pause-dispense-form.component.tsx
+++ b/src/forms/pause-dispense-form.component.tsx
@@ -184,10 +184,7 @@ const PauseDispenseForm: React.FC<PauseDispenseFormProps> = ({
           />
         )}
         {patient && (
-          <ExtensionSlot
-            extensionSlotName="patient-header-slot"
-            state={bannerState}
-          />
+          <ExtensionSlot name="patient-header-slot" state={bannerState} />
         )}
         <section className={styles.formGroup}>
           <ComboBox


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Removes the deprecated `extensionSlotName` prop and replaces it with `name`.