### PR TITLE
(fix) Fix typo in extension config for the dispensing app menu link

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -14,7 +14,7 @@
   "extensions": [
     {
       "name": "dispensing-link",
-      "slot": "app-menu-link",
+      "slot": "app-menu-slot",
       "component": "dispensingLink",
       "online": true,
       "offline": true


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Fixes a typo in the `slot` name.