### PR TITLE
(feat) Tweaks to the dashboard header

### DIFF
--- a/src/medication-request/medication-request.resource.tsx
+++ b/src/medication-request/medication-request.resource.tsx
@@ -102,7 +102,7 @@ export function usePrescriptionsTable(
 
   return {
     prescriptionsTableRows,
-    isError: error,
+    error: error,
     isLoading: !prescriptionsTableRows && !error,
     totalOrders: data?.data.total,
   };

--- a/src/pharmacy-header/pharmacy-header.component.tsx
+++ b/src/pharmacy-header/pharmacy-header.component.tsx
@@ -17,13 +17,15 @@ export const PharmacyHeader: React.FC = () => {
       <div className={styles["left-justified-items"]}>
         <PharmacyIllustration />
         <div className={styles["page-labels"]}>
-          <Location size={16} />
-          <span className={styles.value}>{userLocation}</span>
-          <p className={styles["page-name"]}>{t("appName", config.appName)} </p>
+          <p>{t("appName", config.appName)}</p>
+          <p className={styles["page-name"]}>{t("home", "Home")}</p>
         </div>
       </div>
       <div className={styles["right-justified-items"]}>
         <div className={styles["date-and-location"]}>
+          <Location size={16} />
+          <span className={styles.value}>{userLocation}</span>
+          <span className={styles.middot}>&middot;</span>
           <Calendar size={16} />
           <span className={styles.value}>
             {formatDate(new Date(), { mode: "standard" })}

--- a/src/pharmacy-header/pharmacy-header.scss
+++ b/src/pharmacy-header/pharmacy-header.scss
@@ -8,7 +8,6 @@
   height: spacing.$spacing-12;
   background-color: $ui-02;
   display: flex;
-  padding-left: 8px;
   justify-content: space-between;
 }
 
@@ -16,6 +15,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
+  margin-left: 0.75rem;
 }
 
 .right-justified-items {
@@ -29,7 +29,7 @@
 }
 
 .page-labels {
-  margin-left: 8px;
+  margin-left: 1rem;
   p:first-of-type {
     margin-bottom: 0.25rem;
   }

--- a/src/pharmacy-header/pharmacy-illustration.component.tsx
+++ b/src/pharmacy-header/pharmacy-illustration.component.tsx
@@ -3,8 +3,8 @@ import React from "react";
 const PharmacyIllustration: React.FC = () => {
   return (
     <svg
-      width="62"
-      height="58"
+      width="72"
+      height="72"
       viewBox="0 0 62 58"
       xmlns="http://www.w3.org/2000/svg"
     >

--- a/src/prescriptions/prescription-tab-panel.component.tsx
+++ b/src/prescriptions/prescription-tab-panel.component.tsx
@@ -15,7 +15,6 @@ import {
   TableRow,
   TabPanel,
 } from "@carbon/react";
-
 import { useTranslation } from "react-i18next";
 
 import { formatDatetime, parseDate, useConfig } from "@openmrs/esm-framework";
@@ -40,7 +39,7 @@ const PrescriptionTabPanel: React.FC<PrescriptionTabPanelProps> = ({
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
   const [nextOffSet, setNextOffSet] = useState(0);
-  const { prescriptionsTableRows, isError, isLoading, totalOrders } =
+  const { prescriptionsTableRows, error, isLoading, totalOrders } =
     usePrescriptionsTable(
       pageSize,
       nextOffSet,
@@ -78,7 +77,7 @@ const PrescriptionTabPanel: React.FC<PrescriptionTabPanelProps> = ({
     <TabPanel>
       <div className={styles.patientListTableContainer}>
         {isLoading && <DataTableSkeleton role="progressbar" />}
-        {isError && <p>Error</p>}
+        {error && <p>Error</p>}
         {prescriptionsTableRows && (
           <>
             <DataTable


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR tweaks several aspects of the Dispensing app landing page header, including:

- Changing the appearance of the app name and the page title to match our [design conventions](https://zeroheight.com/23a080e38/p/8358ed-page-header).
- Renaming a variable (unrelated)

## Screenshots

> Before

<img width="1153" alt="CleanShot 2023-08-27 at 1 05 47@2x" src="https://github.com/openmrs/openmrs-esm-dispensing-app/assets/8509731/749bff5e-0078-46bb-9c26-ee7bf36c74e1">

> After

<img width="1154" alt="CleanShot 2023-08-27 at 1 04 32@2x" src="https://github.com/openmrs/openmrs-esm-dispensing-app/assets/8509731/ffb6f860-2caa-4235-8d51-05e6d27d2fc5">

