### PR TITLE
O3-2696 Add ability to configure dispensing app to homepage

### DIFF
--- a/src/dashboard/dispensing-dashboard-link.component.tsx
+++ b/src/dashboard/dispensing-dashboard-link.component.tsx
@@ -1,0 +1,36 @@
+import { ConfigurableLink } from "@openmrs/esm-framework";
+import React, { useMemo } from "react";
+import classNames from "classnames";
+import { useTranslation } from "react-i18next";
+import { BrowserRouter } from "react-router-dom";
+
+const DispensingDashboardLink = () => {
+  return (
+    <BrowserRouter>
+      <DashboardExtension />
+    </BrowserRouter>
+  );
+};
+
+export default DispensingDashboardLink;
+
+function DashboardExtension() {
+  const { t } = useTranslation();
+  const spaBasePath = `${window.spaBase}/home`;
+  const navLink = useMemo(() => {
+    const pathArray = location.pathname.split("/home");
+    const lastElement = pathArray[pathArray.length - 1];
+    return decodeURIComponent(lastElement);
+  }, [location.pathname]);
+
+  return (
+    <ConfigurableLink
+      className={classNames("cds--side-nav__link", {
+        "active-left-nav-link": navLink.match("dispensing"),
+      })}
+      to={`${spaBasePath}/dispensing`}
+    >
+      {t("dispensing", "Dispensing")}
+    </ConfigurableLink>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { configSchema } from "./config-schema";
 import dispensingComponent from "./dispensing.component";
 import dispensingLinkComponent from "./dispensing-link.component";
 import dispensingDashboardComponent from "./dashboard/dispensing-dashboard.component";
+import dispensingLinkHomepageComponent from "./dashboard/dispensing-dashboard-link.component";
 
 export const importTranslation = require.context(
   "../translations",
@@ -33,3 +34,8 @@ export const dispensingDashboard = getSyncLifecycle(
 export function startupApp() {
   defineConfigSchema(moduleName, configSchema);
 }
+
+export const dispensingDashboardLink = getSyncLifecycle(
+  dispensingLinkHomepageComponent,
+  options
+);

--- a/src/routes.json
+++ b/src/routes.json
@@ -25,6 +25,15 @@
       "component": "dispensingDashboard",
       "online": true,
       "offline": true
+    },
+    {
+      "name": "dispensing-dashboard-link",
+      "component": "dispensingDashboardLink",
+      "meta": {
+        "name": "dispensing",
+        "slot": "dispensing-dashboard-slot",
+        "title": "Dispensing"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

This pr will add the dispensing app to the home app. It is a configurable link and implementer's who need the link can add it like using : 

```
"@openmrs/esm-home-app": {
    "extensionSlots": {
      "homepage-dashboard-slot": {
        "add": [
          "dispensing-dashboard-link"
        ]
      }
    }
  }
```

## Screenshots
<!-- Required if you are making UI changes. -->
https://www.loom.com/share/8c2e46878666400390841fa726360af1?sid=e7f8c4b3-b74c-4c0a-9c0c-0938fcd9a5e8

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
