### PR TITLE
(chore) Loosen fhir2 dependency requirement

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -1,6 +1,6 @@
 {
   "backendDependencies": {
-    "fhir2": "^1.2.0",
+    "fhir2": ">=1.2",
     "webservices.rest": "^2.2.0"
   },
   "pages": [


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This commit changes the [fhir2 backend module](https://github.com/openmrs/openmrs-module-fhir2) dependency version requirement from a caret range (^1.2.0) to a range that allows any version greater than or equal to 1.2 (>=1.2).

## Screenshots

Should help fix this error on dev3:

![CleanShot 2024-03-01 at 12  34 35@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/84d332e2-417d-4bba-a877-f92dc19d5dba)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
