### PR TITLE
(feat) Use snackbars for notifications

### DIFF
--- a/src/forms/close-dispense-form.component.tsx
+++ b/src/forms/close-dispense-form.component.tsx
@@ -1,21 +1,14 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  ExtensionSlot,
-  showNotification,
-  showToast,
-  useConfig,
-  useLayoutType,
-  usePatient,
-} from '@openmrs/esm-framework';
 import { Button, ComboBox, InlineLoading } from '@carbon/react';
+import { ExtensionSlot, showSnackbar, useConfig, useLayoutType, usePatient } from '@openmrs/esm-framework';
 import { saveMedicationDispense, useReasonForCloseValueSet } from '../medication-dispense/medication-dispense.resource';
 import { closeOverlay } from '../hooks/useOverlay';
-import styles from './forms.scss';
 import { updateMedicationRequestFulfillerStatus } from '../medication-request/medication-request.resource';
 import { type MedicationDispense, MedicationDispenseStatus, MedicationRequestFulfillerStatus } from '../types';
 import { type PharmacyConfig } from '../config-schema';
 import { getUuidFromReference, revalidate } from '../utils';
+import styles from './forms.scss';
 
 interface CloseDispenseFormProps {
   medicationDispense: MedicationDispense;
@@ -86,10 +79,9 @@ const CloseDispenseForm: React.FC<CloseDispenseFormProps> = ({
           if (response.ok) {
             closeOverlay();
             revalidate(encounterUuid);
-            showToast({
-              critical: true,
+            showSnackbar({
               kind: 'success',
-              description: t(
+              subtitle: t(
                 mode === 'enter' ? 'medicationDispenseClosed' : 'medicationDispenseUpdated',
                 mode === 'enter' ? 'Medication dispense closed.' : 'Dispense record successfully updated.',
               ),
@@ -101,14 +93,13 @@ const CloseDispenseForm: React.FC<CloseDispenseFormProps> = ({
           }
         })
         .catch((error) => {
-          showNotification({
+          showSnackbar({
             title: t(
               mode === 'enter' ? 'medicationDispenseCloseError' : 'medicationDispenseUpdatedError',
               mode === 'enter' ? 'Error closing medication dispense.' : 'Error updating dispense record',
             ),
             kind: 'error',
-            critical: true,
-            description: error?.message,
+            subtitle: error?.message,
           });
           setIsSubmitting(false);
         });

--- a/src/forms/dispense-form.component.tsx
+++ b/src/forms/dispense-form.component.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, FormLabel, InlineLoading } from '@carbon/react';
-import { ExtensionSlot, showNotification, showToast, useConfig, usePatient } from '@openmrs/esm-framework';
+import { ExtensionSlot, showSnackbar, useConfig, usePatient } from '@openmrs/esm-framework';
 import { closeOverlay } from '../hooks/useOverlay';
 import {
   type MedicationDispense,
@@ -91,15 +91,18 @@ const DispenseForm: React.FC<DispenseFormProps> = ({
             );
             sendStockDispenseRequest(stockDispenseRequestPayload, abortController).then(
               () => {
-                showToast({
-                  critical: true,
+                showSnackbar({
                   title: t('stockDispensed', 'Stock dispensed'),
                   kind: 'success',
-                  description: t('stockDispensedSuccessfully', 'Stock dispensed successfully and batch level updated.'),
+                  subtitle: t('stockDispensedSuccessfully', 'Stock dispensed successfully and batch level updated.'),
                 });
               },
               (error) => {
-                showToast({ title: 'Stock dispense error', kind: 'error', description: error?.message });
+                showSnackbar({
+                  title: 'Stock dispense error',
+                  kind: 'error',
+                  subtitle: error?.message,
+                });
               },
             );
           }
@@ -110,10 +113,9 @@ const DispenseForm: React.FC<DispenseFormProps> = ({
             if (status === 201 || status === 200) {
               closeOverlay();
               revalidate(encounterUuid);
-              showToast({
-                critical: true,
+              showSnackbar({
                 kind: 'success',
-                description: t('medicationListUpdated', 'Medication dispense list has been updated.'),
+                subtitle: t('medicationListUpdated', 'Medication dispense list has been updated.'),
                 title: t(
                   mode === 'enter' ? 'medicationDispensed' : 'medicationDispenseUpdated',
                   mode === 'enter' ? 'Medication successfully dispensed.' : 'Dispense record successfully updated.',
@@ -122,14 +124,13 @@ const DispenseForm: React.FC<DispenseFormProps> = ({
             }
           },
           (error) => {
-            showNotification({
+            showSnackbar({
+              kind: 'error',
               title: t(
                 mode === 'enter' ? 'medicationDispenseError' : 'medicationDispenseUpdatedError',
                 mode === 'enter' ? 'Error dispensing medication.' : 'Error updating dispense record',
               ),
-              kind: 'error',
-              critical: true,
-              description: error?.message,
+              subtitle: error?.message,
             });
             setIsSubmitting(false);
           },

--- a/src/forms/pause-dispense-form.component.tsx
+++ b/src/forms/pause-dispense-form.component.tsx
@@ -1,21 +1,14 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  ExtensionSlot,
-  showNotification,
-  showToast,
-  useConfig,
-  useLayoutType,
-  usePatient,
-} from '@openmrs/esm-framework';
 import { Button, ComboBox, InlineLoading } from '@carbon/react';
+import { ExtensionSlot, showSnackbar, useConfig, useLayoutType, usePatient } from '@openmrs/esm-framework';
 import { saveMedicationDispense, useReasonForPauseValueSet } from '../medication-dispense/medication-dispense.resource';
 import { closeOverlay } from '../hooks/useOverlay';
-import styles from './forms.scss';
 import { updateMedicationRequestFulfillerStatus } from '../medication-request/medication-request.resource';
 import { getUuidFromReference, revalidate } from '../utils';
 import { type MedicationDispense, MedicationDispenseStatus, MedicationRequestFulfillerStatus } from '../types';
 import { type PharmacyConfig } from '../config-schema';
+import styles from './forms.scss';
 
 interface PauseDispenseFormProps {
   medicationDispense: MedicationDispense;
@@ -86,10 +79,9 @@ const PauseDispenseForm: React.FC<PauseDispenseFormProps> = ({
           if (response.ok) {
             closeOverlay();
             revalidate(encounterUuid);
-            showToast({
-              critical: true,
+            showSnackbar({
               kind: 'success',
-              description: t(
+              subtitle: t(
                 mode === 'enter' ? 'medicationDispensePaused' : 'medicationDispenseUpdated',
                 mode === 'enter' ? 'Medication dispense paused.' : 'Dispense record successfully updated.',
               ),
@@ -101,14 +93,13 @@ const PauseDispenseForm: React.FC<PauseDispenseFormProps> = ({
           }
         })
         .catch((error) => {
-          showNotification({
+          showSnackbar({
             title: t(
               mode === 'enter' ? 'medicationDispensePauseError' : 'medicationDispenseUpdatedError',
               mode === 'enter' ? 'Error pausing medication dispense.' : 'Error updating dispense record',
             ),
             kind: 'error',
-            critical: true,
-            description: error?.message,
+            subtitle: error?.message,
           });
           setIsSubmitting(false);
         });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR replaces the use of toast notifications with snackbars, which are more consistent with the rest of the application. Toast notifications are best suited for displaying system generated notifications per the [notification design docs](https://zeroheight.com/23a080e38/p/683580-notifications).

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
