### PR TITLE
O3-4210: Fix button alignment to bottom-right and update button order

### DIFF
--- a/src/components/action-buttons.scss
+++ b/src/components/action-buttons.scss
@@ -1,9 +1,15 @@
 .actionBtns {
-  float: right;
-  margin-left: 1rem;
-  margin-top: 2rem;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  display: flex;
+  gap: 0;
 }
 
 .extensionSlot {
   display: flex;
+  flex-direction: row-reverse;
+  justify-content: space-between;
+  height: 100%;
+  position: relative;
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR addresses the issue where buttons in the UI appear misaligned and 'float' when the vertical height increases. Additionally, the button order has been adjusted to improve user flow and intuitiveness, with the primary action ('Dispense') moved to the right and destructive actions ('Pause' and 'Close') placed on the left with secondary or tertiary styling for better visual hierarchy.

## Screenshots

https://github.com/user-attachments/assets/65533ef1-23d8-4035-9c17-26ccee5f57ac


https://github.com/user-attachments/assets/608cd69c-1596-4436-9165-a722c56811b7




## Related Issue
https://openmrs.atlassian.net/browse/O3-4210

## Other
<!-- Anything not covered above -->
