### PR TITLE
(fix) O3-4350: Improper left horizontal alignment in dispensing dashboard

### DIFF
--- a/src/pharmacy-header/pharmacy-header.scss
+++ b/src/pharmacy-header/pharmacy-header.scss
@@ -15,7 +15,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  margin-left: 0.75rem;
+  margin-left: 1rem;
 }
 
 .right-justified-items {

--- a/src/prescriptions/prescriptions.scss
+++ b/src/prescriptions/prescriptions.scss
@@ -47,6 +47,7 @@ title {
 
 .tabsContainer {
   background-color: $ui-02;
+  padding: 0 spacing.$spacing-05;
 
   :global(.cds--tabs__nav-item--selected) {
     box-shadow: inset 0 2px 0 0 var(--brand-03) !important;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR addresses the issue where the left side of the Dispensing Dashboard lacked proper alignment due to inconsistent margin or padding. A consistent 16px margin/padding has been added to the left side, ensuring better alignment and improving the overall user experience with a visually balanced layout.

## Screenshots
### Before
<img width="414" alt="Screenshot 2025-01-15 at 9 09 02 AM" src="https://github.com/user-attachments/assets/be70dd50-73d2-48fd-874a-ff49f0862fc2" />

### After
<img width="416" alt="Screenshot 2025-01-15 at 10 05 36 AM" src="https://github.com/user-attachments/assets/35363b6a-ea87-4fa9-be31-7c982875aee5" />

## Related Issue
[O3-4350](https://openmrs.atlassian.net/jira/software/c/projects/O3/issues/O3-4350?jql=project%20%3D%20%22O3%22%20ORDER%20BY%20created%20DESC)

