### PR TITLE
(feat) O3-4575:Sort stock item batches by expiry date in ascending order

### DIFF
--- a/src/forms/stock-dispense/stock-dispense.component.tsx
+++ b/src/forms/stock-dispense/stock-dispense.component.tsx
@@ -15,15 +15,9 @@ const StockDispense: React.FC<StockDispenseProps> = ({ medicationDispense, updat
   const { t } = useTranslation();
   const drugUuid = medicationDispense?.medicationReference?.reference?.split('/')[1];
   const { inventoryItems, error, isLoading } = useDispenseStock(drugUuid);
-  const validInventoryItems = inventoryItems.filter((item) => isValidBatch(medicationDispense, item));
-  const validInventoryItemss = inventoryItems
+  const validInventoryItems = inventoryItems
     .filter((item) => isValidBatch(medicationDispense, item))
-    .sort((a, b) => {
-      const dateA = new Date(a.expiration);
-      const dateB = new Date(b.expiration);
-
-      return dateA.getDate() - dateB.getDate();
-    });
+    .sort((a, b) => new Date(a.expiration).getTime() - new Date(b.expiration).getTime());
 
   function parseDate(dateString) {
     return new Date(dateString);


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
As a pharmacist,I want stock item batches to be sorted in ascending order by expiry date, I can prioritize dispensing batches that are closer to expiry first, minimizing wastage and ensuring efficient inventory management.
## Screenshots
<!-- Required if you are making UI changes. -->
![Screenshot from 2025-03-27 23-24-05](https://github.com/user-attachments/assets/7fbb8985-76ff-4a3a-8f43-cec9533688a8)
## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4575
## Other
<!-- Anything not covered above -->
