### PR TITLE
(fix)O3-4651: Change edit menu alignment in history and comments

### DIFF
--- a/src/history/history-and-comments.component.tsx
+++ b/src/history/history-and-comments.component.tsx
@@ -231,11 +231,11 @@ const HistoryAndComments: React.FC<{
                   {formatDatetime(parseDate(dispense.whenHandedOver))}
                 </h5>
                 <Tile className={styles.dispenseTile} data-floating-menu-container>
+                  <MedicationEvent medicationEvent={dispense} status={generateDispenseTag(dispense)} />
                   {generateMedicationDispenseActionMenu(
                     dispense,
                     getMedicationRequestBundleContainingMedicationDispense(medicationRequestBundles, dispense),
                   )}
-                  <MedicationEvent medicationEvent={dispense} status={generateDispenseTag(dispense)} />
                 </Tile>
               </div>
             );

--- a/src/history/history-and-comments.scss
+++ b/src/history/history-and-comments.scss
@@ -39,6 +39,8 @@
   }
 
   .dispenseTile {
+    display: flex;
+    justify-content: space-between;
     width: 100%;
     margin: layout.$spacing-01 0 layout.$spacing-03;
     padding: 0 layout.$spacing-03 0 layout.$spacing-03;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR is responsible to rectify the alignment of the edit OverFlow menu 

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="1687" alt="image" src="https://github.com/user-attachments/assets/631e9758-acc8-4f4d-a87a-b7b458336c79" />


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
