### PR TITLE
(fix) O3-4670:  Fix overflow menu misalignment in "History and Comments" view 

### DIFF
--- a/src/history/history-and-comments.component.tsx
+++ b/src/history/history-and-comments.component.tsx
@@ -237,7 +237,7 @@ const HistoryAndComments: React.FC<{
                   {dispense.performer && dispense.performer[0]?.actor?.display} {generateDispenseVerbiage(dispense)} -{' '}
                   {formatDatetime(parseDate(dispense.whenHandedOver))}
                 </h5>
-                <Tile className={styles.dispenseTile} data-floating-menu-container>
+                <Tile className={styles.dispenseTile}>
                   <MedicationEvent medicationEvent={dispense} status={generateDispenseTag(dispense)} />
                   {generateMedicationDispenseActionMenu(
                     dispense,

--- a/src/history/history-and-comments.component.tsx
+++ b/src/history/history-and-comments.component.tsx
@@ -148,18 +148,24 @@ const HistoryAndComments: React.FC<{
     } else {
       return (
         <OverflowMenu
-          ariaLabel={t('medicationDispenseActionMenu', 'Medication Dispense Action Menu')}
-          flipped={true}
-          className={styles.medicationEventActionMenu}>
+          aria-label={t('medicationDispenseActionMenu', 'Medication Dispense Action Menu')}
+          className={styles.medicationEventActionMenu}
+          flipped>
           {editable && (
-            <OverflowMenuItem onClick={handleEdit} itemText={t('editRecord', 'Edit record')}></OverflowMenuItem>
+            <OverflowMenuItem
+              className={styles.menuitem}
+              itemText={t('editRecord', 'Edit record')}
+              onClick={handleEdit}
+            />
           )}
           {deletable && (
             <OverflowMenuItem
-              onClick={() => {
-                handleDelete(medicationDispense, medicationRequestBundle);
-              }}
-              itemText={t('delete', 'Delete')}></OverflowMenuItem>
+              className={styles.menuitem}
+              hasDivider
+              isDelete
+              itemText={t('delete', 'Delete')}
+              onClick={() => handleDelete(medicationDispense, medicationRequestBundle)}
+            />
           )}
         </OverflowMenu>
       );

--- a/src/history/history-and-comments.scss
+++ b/src/history/history-and-comments.scss
@@ -43,7 +43,7 @@
     justify-content: space-between;
     width: 100%;
     margin: layout.$spacing-01 0 layout.$spacing-03;
-    padding: 0 layout.$spacing-03 0 layout.$spacing-03;
+    padding: 0 0 0 layout.$spacing-03;
     background-color: #fff;
     border-left: layout.$spacing-03 solid red;
     color: $text-02;
@@ -53,4 +53,8 @@
   .medicationEventActionMenu {
     float: right;
   }
+}
+
+.menuitem {
+  max-width: none;
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes a UI issue  in the `History and Comments` section for closed or dispensed prescriptions where clicking the overflow menu caused the menu to layout shift to the left. Removing the `data-floating-menu-container` prop from the `Tile` component fixes the issue.

## Screenshots

### Before
<img width="1470" alt="Screenshot 2025-04-28 at 5 44 05 PM" src="https://github.com/user-attachments/assets/f07eeae0-c8ee-4417-8a3e-d0bfedc73278" />

### After
<img width="1470" alt="Screenshot 2025-04-28 at 5 58 42 PM" src="https://github.com/user-attachments/assets/c59ca017-169b-41b2-9d7b-81fe22fe8ee2" />

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[jira ticket](https://openmrs.atlassian.net/browse/O3-4670)

## Other
<!-- Anything not covered above -->
