### PR TITLE
(feat) 03-4674 : Add confirmation modal for medication dispense deletion

### DIFF
--- a/src/history/delete-confrim.modal.tsx
+++ b/src/history/delete-confrim.modal.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Button, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
+import { useTranslation } from 'react-i18next';
+
+const DeleteConfirmModal = ({
+  title,
+  onClose,
+  onDelete,
+
+  message,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  onDelete: () => void;
+  title: string;
+  message: string;
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <React.Fragment>
+      <ModalHeader closeModal={onClose} title={title}></ModalHeader>
+      <ModalBody>{message}</ModalBody>
+      <ModalFooter>
+        <Button kind="secondary" onClick={onClose}>
+          {t('cancel', 'Cancel')}
+        </Button>
+        <Button kind="danger" onClick={onDelete}>
+          {t('delete', 'Delete')}
+        </Button>
+      </ModalFooter>
+    </React.Fragment>
+  );
+};
+export default DeleteConfirmModal;

--- a/src/history/history-and-comments.component.tsx
+++ b/src/history/history-and-comments.component.tsx
@@ -6,6 +6,7 @@ import {
   launchWorkspace,
   parseDate,
   type Session,
+  showModal,
   useConfig,
   userHasAccess,
   useSession,
@@ -142,6 +143,19 @@ const HistoryAndComments: React.FC<{
       const workspaceTitle = getWorkspaceTitle(medicationDispense);
       launchWorkspace(workspaceName, { workspaceTitle, ...props });
     };
+    const handleDeleteClick = ({ medicationDispense, medicationRequestBundle }) => {
+      const dispose = showModal('delete-confirm-modal', {
+        title: t('deleteDispenseRecord', 'Delete Dispense Record'),
+        message: t('deleteDispenseRecordMessage', 'Are you sure you want to delete this dispense record?'),
+        onDelete: () => {
+          handleDelete(medicationDispense, medicationRequestBundle);
+          dispose();
+        },
+        onClose: () => {
+          dispose();
+        },
+      });
+    };
 
     if (!editable && !deletable) {
       return null;
@@ -164,7 +178,7 @@ const HistoryAndComments: React.FC<{
               hasDivider
               isDelete
               itemText={t('delete', 'Delete')}
-              onClick={() => handleDelete(medicationDispense, medicationRequestBundle)}
+              onClick={() => handleDeleteClick({ medicationDispense, medicationRequestBundle })}
             />
           )}
         </OverflowMenu>

--- a/src/history/history-and-comments.component.tsx
+++ b/src/history/history-and-comments.component.tsx
@@ -226,8 +226,8 @@ const HistoryAndComments: React.FC<{
       .then(() => {
         showSnackbar({
           kind: 'success',
-          title: 'Success',
-          subtitle: 'Medication dispense was deleted successfully',
+          title: t('success', 'Success'),
+          subtitle: t('medicationDispenseDeleted', 'Medication dispense was deleted successfully'),
         });
         if (currentFulfillerStatus !== newFulfillerStatus) {
           updateMedicationRequestFulfillerStatus(
@@ -242,8 +242,8 @@ const HistoryAndComments: React.FC<{
             .catch(() => {
               showSnackbar({
                 kind: 'error',
-                title: 'Update Status Failed',
-                subtitle: 'Could not update medication request status',
+                title: t('updateStatusFailed', 'Update Status Failed'),
+                subtitle: t('couldNotUpdateMedicationRequestStatus', 'Could not update medication request status'),
               });
             });
         }
@@ -252,8 +252,8 @@ const HistoryAndComments: React.FC<{
       .catch(() => {
         showSnackbar({
           kind: 'error',
-          title: 'Delete Failed',
-          subtitle: 'Could not delete medication dispense',
+          title: t('deleteFailed', 'Delete Failed'),
+          subtitle: t('couldNotDeleteMedicationDispense', 'Could not delete medication dispense'),
         });
       });
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ export const dispenseWorkspace = getAsyncLifecycle(() => import('./forms/dispens
 export const pauseDispenseWorkspace = getAsyncLifecycle(() => import('./forms/pause-dispense-form.workspace'), options);
 
 export const printPrescriptionPreviewModal = getSyncLifecycle(PrescriptionPrintPreviewModal, options);
+export const deleteConfirmModal = getAsyncLifecycle(() => import('./history/delete-confrim.modal'), options);
 
 export const patientDiagnoses = getAsyncLifecycle(() => import('./diagnoses/diagnoses.component'), options);
 export const patientConditions = getAsyncLifecycle(() => import('./conditions/conditions.component'), options);

--- a/src/routes.json
+++ b/src/routes.json
@@ -91,6 +91,11 @@
     {
       "name": "prescription-print-preview-modal",
       "component": "printPrescriptionPreviewModal"
+    },
+    {
+      "name": "delete-confirm-modal",
+      "component": "deleteConfirmModal"
+
     }
   ]
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
### Overview
This PR adds a confirmation modal when deleting medication dispense records to prevent accidental deletions and improve user experience.and medication dispense deletion by adding proper error handling and success/failure notifications.


##### Key Changes
- Added a new delete confirmation modal component
- Implemented modal handling logic in `history-and-comments.component.tsx`
- Registered the new modal in `routes.json` and `index.ts`
- Updated the delete action flow to show confirmation before proceeding
- Added `success snackbar` notification after successful deletion
- Added error handling and `error snackbar` for failed medication request status updates

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="1470" alt="Screenshot 2025-05-01 at 9 47 52 AM" src="https://github.com/user-attachments/assets/37906934-2a13-4ff4-bf31-3afa465753ad" />

## confirmation modal
<img width="1470" alt="Screenshot 2025-05-01 at 9 47 43 AM" src="https://github.com/user-attachments/assets/ce466a61-9d10-4539-8284-27dd4c379198" />

## after success snackbar
<img width="1470" alt="Screenshot 2025-05-01 at 9 48 00 AM" src="https://github.com/user-attachments/assets/3a3ecff0-cc17-4068-92cd-d8ff0973558e" />



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[jira ticket](https://openmrs.atlassian.net/browse/O3-4674)

## Other
<!-- Anything not covered above -->
