### PR TITLE
(fix) O3-4761 Allow dashboard extension to work in other apps

### DIFF
--- a/src/dashboard/dispensing-dashboard.component.tsx
+++ b/src/dashboard/dispensing-dashboard.component.tsx
@@ -1,18 +1,12 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { InlineNotification } from '@carbon/react';
-import { setLeftNav, unsetLeftNav, useConfig, WorkspaceContainer } from '@openmrs/esm-framework';
+import { useConfig } from '@openmrs/esm-framework';
 import { type PharmacyConfig } from '../config-schema';
 import { PharmacyHeader } from '../pharmacy-header/pharmacy-header.component';
 import PrescriptionTabLists from '../prescriptions/prescription-tab-lists.component';
 
 export default function DispensingDashboard() {
-  useEffect(() => {
-    const basePath = window.spaBase + '/dispensing';
-    setLeftNav({ name: 'homepage-dashboard-slot', basePath, mode: 'collapsed' });
-    return () => unsetLeftNav('homepage-dashboard-slot');
-  }, []);
-
   const config = useConfig<PharmacyConfig>();
   const { t } = useTranslation();
   if (config.dispenseBehavior.restrictTotalQuantityDispensed && config.dispenseBehavior.allowModifyingPrescription) {
@@ -33,7 +27,6 @@ export default function DispensingDashboard() {
         <PharmacyHeader />
         {/* <DispensingTiles /> */}
         <PrescriptionTabLists />
-        <WorkspaceContainer key="dispensing" contextKey="dispensing" />
       </div>
     );
   }

--- a/src/dispensing.component.tsx
+++ b/src/dispensing.component.tsx
@@ -1,6 +1,17 @@
-import React from 'react';
-import { ExtensionSlot } from '@openmrs/esm-framework';
+import React, { useEffect } from 'react';
+import { ExtensionSlot, setLeftNav, unsetLeftNav, WorkspaceContainer } from '@openmrs/esm-framework';
 
 export default function Dispensing() {
-  return <ExtensionSlot name="dispensing-dashboard-slot" />;
+  useEffect(() => {
+    const basePath = window.spaBase + '/dispensing';
+    setLeftNav({ name: 'homepage-dashboard-slot', basePath, mode: 'collapsed' });
+    return () => unsetLeftNav('homepage-dashboard-slot');
+  }, []);
+
+  return (
+    <>
+      <ExtensionSlot name="dispensing-dashboard-slot" />
+      <WorkspaceContainer key="dispensing" contextKey="dispensing" />
+    </>
+  );
 }


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Minor change to move things around, so that both the left nav and the `<WorkspaceContainer>` are not part of the `dispensing-dashboard` extension. This allows it to be slotted into other apps that can have its own left nav and URL mount point.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4761
## Other
<!-- Anything not covered above -->
