### PR TITLE
(feat) auto-select currently logged-in user as dispenser on dispensing form

### DIFF
--- a/src/forms/medication-dispense-review.component.tsx
+++ b/src/forms/medication-dispense-review.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import { ComboBox, Dropdown, NumberInput, Stack, TextArea } from '@carbon/react';
@@ -207,6 +207,32 @@ const MedicationDispenseReview: React.FC<MedicationDispenseReviewProps> = ({
   useEffect(() => {
     setUserCanModify(session?.user && userHasAccess(PRIVILEGE_CREATE_DISPENSE_MODIFY_DETAILS, session.user));
   }, [session]);
+
+  const initialDispenser = useMemo(() => {
+    return medicationDispense?.performer?.[0]?.actor?.reference
+      ? providers?.find((provider) => provider.uuid === medicationDispense.performer[0].actor.reference.split('/')[1])
+      : {
+          uuid: session?.currentProvider?.uuid ?? '',
+          person: {
+            display: session?.user?.person?.display ?? '',
+          },
+        };
+  }, [medicationDispense?.performer, providers, session?.currentProvider?.uuid, session?.user?.person?.display]);
+
+  useEffect(() => {
+    if (initialDispenser?.uuid) {
+      updateMedicationDispense({
+        ...medicationDispense,
+        performer: [
+          {
+            actor: {
+              reference: `Practitioner/${initialDispenser.uuid}`,
+            },
+          },
+        ],
+      });
+    }
+  }, [initialDispenser, medicationDispense, updateMedicationDispense]);
 
   return (
     <div className={styles.medicationDispenseReviewContainer}>
@@ -546,13 +572,7 @@ const MedicationDispenseReview: React.FC<MedicationDispenseReviewProps> = ({
           <ResponsiveWrapper>
             <ComboBox
               id="dispenser"
-              initialSelectedItem={
-                medicationDispense?.performer[0].actor.reference
-                  ? providers.find(
-                      (provider) => provider.uuid === medicationDispense?.performer[0].actor.reference.split('/')[1],
-                    )
-                  : null
-              }
+              initialSelectedItem={initialDispenser}
               onChange={({ selectedItem }) => {
                 updateMedicationDispense({
                   ...medicationDispense,


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
In the event `medicationDispense.performer` is null, auto-select the logged in user as the dispenser

## Screenshots
### bug
![Screenshot 2025-05-29 at 22 30 03](https://github.com/user-attachments/assets/b3da9e84-fccd-4e3a-9edc-765102bf097c)
### fix
![Screenshot 2025-05-29 at 22 30 25](https://github.com/user-attachments/assets/113241d3-ae49-475f-a446-584a59231154)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
