### PR TITLE
(fix) O3-4782 Fix dispensing tables not being displayed

### DIFF
--- a/src/prescriptions/prescription-tab-lists.component.tsx
+++ b/src/prescriptions/prescription-tab-lists.component.tsx
@@ -94,17 +94,15 @@ const PrescriptionTabLists: React.FC = () => {
                   />
                 )}
             </div>
-            <div className={styles.hiddenTabsContent}>
-              <TabPanels>
-                {tabs.map((tab, index) => {
-                  return index === selectedTab ? (
-                    <PrescriptionTabPanel location={location} searchTerm={searchTerm} status={tab.status} />
-                  ) : (
-                    <></>
-                  );
-                })}
-              </TabPanels>
-            </div>
+            <TabPanels>
+              {tabs.map((tab, index) => {
+                return index === selectedTab ? (
+                  <PrescriptionTabPanel location={location} searchTerm={searchTerm} status={tab.status} />
+                ) : (
+                  <></>
+                );
+              })}
+            </TabPanels>
           </Tabs>
         </div>
       </section>

--- a/src/prescriptions/prescriptions.scss
+++ b/src/prescriptions/prescriptions.scss
@@ -44,11 +44,6 @@
   }
 }
 
-.hiddenTabsContent,
-.tabs .hiddenTabsContent {
-  display: none;
-}
-
 .patientListTableContainer {
   grid-row: 3 / 4;
   grid-column: 1 / 2;


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This fixes a regression caused by CSS stylings shuffling around when we upgraded to latest core [here](https://github.com/openmrs/openmrs-esm-dispensing-app/pull/214). 

## Screenshots
<!-- Required if you are making UI changes. -->
Before:
![Untitled](https://github.com/user-attachments/assets/4d572380-c07b-444b-9b75-39a07c6598a3)

After:
![image](https://github.com/user-attachments/assets/70ac15b5-898f-4603-b0c4-9f032671566d)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4782

## Other
<!-- Anything not covered above -->
