### PR TITLE
(test) O3-4868: Add e2e test for editing a medication dispense event

### DIFF
--- a/e2e/commands/index.ts
+++ b/e2e/commands/index.ts
@@ -1,5 +1,6 @@
 export * from './drug-order-operations';
 export * from './encounter-operations';
+export * from './medication-dispense-operations';
 export * from './patient-operations';
 export * from './provider-operations';
 export * from './visit-operations';

--- a/e2e/commands/medication-dispense-operations.ts
+++ b/e2e/commands/medication-dispense-operations.ts
@@ -1,0 +1,98 @@
+import dayjs from 'dayjs';
+import { type APIRequestContext, expect } from '@playwright/test';
+import { type Patient } from './patient-operations';
+import { type Provider } from './types';
+import { type MedicationDispense, MedicationDispenseStatus } from '../../src/types';
+
+export const generateMedicationDispense = async (
+  fhirApi: APIRequestContext,
+  patient: Patient,
+  provider: Provider,
+  medicationRequestUuid: string,
+): Promise<MedicationDispense> => {
+  const dispense = await fhirApi.post('MedicationDispense', {
+    data: {
+      resourceType: 'MedicationDispense',
+      status: MedicationDispenseStatus.completed,
+      authorizingPrescription: [
+        {
+          reference: `MedicationRequest/${medicationRequestUuid}`,
+          type: 'MedicationRequest',
+        },
+      ],
+      medicationReference: {
+        reference: 'Medication/09e58895-e7f0-4649-b7c0-e665c5c08e93',
+        type: 'Medication',
+        display: 'Aspirin 81mg',
+      },
+      subject: {
+        reference: `Patient/${patient.uuid}`,
+      },
+      performer: [
+        {
+          actor: {
+            reference: `Practitioner/${provider.uuid}`,
+          },
+        },
+      ],
+      location: {
+        reference: `Location/${process.env.E2E_LOGIN_DEFAULT_LOCATION_UUID}`,
+      },
+      substitution: {
+        wasSubstituted: false,
+        reason: [],
+        type: null,
+      },
+      whenHandedOver: dayjs().format(),
+      quantity: {
+        value: 5,
+        code: '1513AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        unit: 'Tablet',
+      },
+      dosageInstruction: [
+        {
+          timing: {
+            repeat: {
+              durationUnit: 'd',
+            },
+            code: {
+              coding: [
+                {
+                  code: '160862AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+                  display: 'Once daily',
+                },
+              ],
+              text: 'Once daily',
+            },
+          },
+          asNeededBoolean: false,
+          route: {
+            coding: [
+              {
+                code: '160240AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+                display: 'Oral',
+              },
+            ],
+            text: 'Oral',
+          },
+          doseAndRate: [
+            {
+              doseQuantity: {
+                value: 1,
+                unit: 'Milligram',
+                code: '161553AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              },
+            },
+          ],
+        },
+      ],
+    },
+  });
+
+  expect(dispense.ok()).toBeTruthy();
+  return await dispense.json();
+};
+
+export const deleteMedicationDispense = async (fhirApi: APIRequestContext, uuid: string) => {
+  await fhirApi.delete(`MedicationDispense/${uuid}`);
+};

--- a/e2e/core/test.ts
+++ b/e2e/core/test.ts
@@ -1,5 +1,5 @@
 import { type APIRequestContext, type Page, test as base } from '@playwright/test';
-import { api } from '../fixtures';
+import { api, fhirApi } from '../fixtures';
 import { type Patient } from '../types';
 import { generateRandomPatient, deletePatient } from '../commands';
 
@@ -16,10 +16,12 @@ export interface CustomTestFixtures {
 
 export interface CustomWorkerFixtures {
   api: APIRequestContext;
+  fhirApi: APIRequestContext;
 }
 
 export const test = base.extend<CustomTestFixtures, CustomWorkerFixtures>({
   api: [api, { scope: 'worker' }],
+  fhirApi: [fhirApi, { scope: 'worker' }],
   patient: [
     async ({ api }, use) => {
       const patient = await generateRandomPatient(api);

--- a/e2e/fixtures/fhirApi.ts
+++ b/e2e/fixtures/fhirApi.ts
@@ -1,0 +1,27 @@
+import { type APIRequestContext, type PlaywrightWorkerArgs, type WorkerFixture } from '@playwright/test';
+
+/**
+ * A fixture which initializes an [`APIRequestContext`](https://playwright.dev/docs/api/class-apirequestcontext)
+ * that is bound to the configured OpenMRS FHIR R4 API server. The context is automatically
+ * authenticated using the configured admin account.
+ *
+ * Use the request context like this:
+ * ```ts
+ * test('your test', async ({ fhirApi }) => {
+ *   const res = await fhirApi.get('MedicationDispense/1234');
+ *   await expect(res.ok()).toBeTruthy();
+ * });
+ * ```
+ */
+
+export const fhirApi: WorkerFixture<APIRequestContext, PlaywrightWorkerArgs> = async ({ playwright }, use) => {
+  const fhirctx = await playwright.request.newContext({
+    baseURL: `${process.env.E2E_BASE_URL}/ws/fhir2/R4/`,
+    httpCredentials: {
+      username: process.env.E2E_USER_ADMIN_USERNAME,
+      password: process.env.E2E_USER_ADMIN_PASSWORD,
+    },
+  });
+
+  use(fhirctx);
+};

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -1,1 +1,2 @@
 export * from './api';
+export * from './fhirApi';

--- a/e2e/specs/edit-medication-dispense.spec.ts
+++ b/e2e/specs/edit-medication-dispense.spec.ts
@@ -1,0 +1,109 @@
+import { expect } from '@playwright/test';
+import { type Order, type Visit } from '@openmrs/esm-framework';
+import {
+  createEncounter,
+  deleteDrugOrder,
+  deleteEncounter,
+  deleteMedicationDispense,
+  endVisit,
+  generateMedicationDispense,
+  generateRandomDrugOrder,
+  getProvider,
+  startVisit,
+} from '../commands';
+import { DispensingPage } from '../pages';
+import { test } from '../core';
+import { type Encounter, type Provider } from '../commands/types';
+import { type MedicationDispense } from '../../src/types';
+
+let visit: Visit;
+let drugOrder: Order;
+let encounter: Encounter;
+let orderer: Provider;
+let medicationDispense: MedicationDispense;
+
+test.beforeEach(async ({ api, fhirApi, patient }) => {
+  visit = await startVisit(api, patient.uuid);
+  orderer = await getProvider(api);
+  encounter = await createEncounter(api, patient.uuid, orderer.uuid, visit);
+  drugOrder = await generateRandomDrugOrder(api, patient.uuid, encounter, orderer.uuid);
+  medicationDispense = await generateMedicationDispense(fhirApi, patient, orderer, drugOrder.uuid);
+
+  // Wait until the dispense is returned by the same FHIR search the prescription
+  // details view issues, so the UI is guaranteed to see it once the test starts
+  await expect
+    .poll(
+      async () => {
+        const response = await fhirApi.get(
+          `MedicationRequest?encounter=${encounter.uuid}&_revinclude=MedicationDispense:prescription`,
+        );
+        if (!response.ok()) {
+          return 0;
+        }
+        const bundle = await response.json();
+        return (
+          bundle.entry?.filter(
+            (entry: { resource?: { resourceType?: string } }) => entry.resource?.resourceType === 'MedicationDispense',
+          ).length ?? 0
+        );
+      },
+      { timeout: 30000 },
+    )
+    .toBeGreaterThan(0);
+});
+
+test('Edit medication dispense', async ({ page }) => {
+  const dispensingPage = new DispensingPage(page);
+
+  await test.step('When I navigate to the dispensing app', async () => {
+    await dispensingPage.goTo();
+    await expect(page).toHaveURL(`${process.env.E2E_BASE_URL}/spa/dispensing`);
+  });
+
+  await test.step('And I click on the "All prescriptions" tab', async () => {
+    await page.getByRole('tab', { name: 'All prescriptions' }).click();
+    await expect(page.getByRole('tab', { name: 'All prescriptions' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  await test.step('Then I should see the prescription in the table', async () => {
+    await expect(page.getByRole('row', { name: 'Expand current row' }).first()).toBeVisible({ timeout: 15000 });
+  });
+
+  await test.step('And I expand the prescription row', async () => {
+    await page.getByRole('row', { name: 'Expand current row' }).getByLabel('Expand current row').first().click();
+  });
+
+  await test.step('And I navigate to the History and comments tab', async () => {
+    await page.getByRole('tab', { name: 'History and comments' }).click();
+    await expect(page.getByText('QUANTITY 5 Tablet')).toBeVisible();
+  });
+
+  await test.step('And I edit the dispense record', async () => {
+    await page.getByLabel('History and comments').getByRole('button', { name: 'Options' }).click();
+    await page.getByRole('menuitem', { name: 'Edit Record' }).click();
+  });
+
+  await test.step('And I update the quantity to 9', async () => {
+    await page.getByRole('spinbutton', { name: 'Quantity' }).click();
+    await page.getByRole('spinbutton', { name: 'Quantity' }).fill('9');
+  });
+
+  await test.step('And I save the changes', async () => {
+    await page.getByRole('button', { name: 'Save changes' }).click();
+  });
+
+  await test.step('Then I should see a success notification confirming the update', async () => {
+    await expect(page.getByText(/medication dispense list has been updated/i)).toBeVisible();
+  });
+
+  await test.step('And the quantity should be updated to 9', async () => {
+    await expect(page.getByText('QUANTITY 9 Tablet')).toBeVisible();
+  });
+});
+
+test.afterEach(async ({ api, fhirApi }) => {
+  await deleteMedicationDispense(fhirApi, medicationDispense.id);
+  await deleteEncounter(api, encounter.uuid);
+  await deleteDrugOrder(api, drugOrder.uuid);
+  await endVisit(api, visit);
+});

--- a/e2e/specs/edit-medication-dispense.spec.ts
+++ b/e2e/specs/edit-medication-dispense.spec.ts
@@ -52,8 +52,10 @@ test.beforeEach(async ({ api, fhirApi, patient }) => {
     .toBeGreaterThan(0);
 });
 
-test('Edit medication dispense', async ({ page }) => {
+test('Edit medication dispense', async ({ page, patient }) => {
   const dispensingPage = new DispensingPage(page);
+  const patientRow = page.getByRole('row', { name: new RegExp(patient.person.display) });
+  const historyTabPanel = page.getByRole('tabpanel', { name: 'History and comments' });
 
   await test.step('When I navigate to the dispensing app', async () => {
     await dispensingPage.goTo();
@@ -65,21 +67,21 @@ test('Edit medication dispense', async ({ page }) => {
     await expect(page.getByRole('tab', { name: 'All prescriptions' })).toHaveAttribute('aria-selected', 'true');
   });
 
-  await test.step('Then I should see the prescription in the table', async () => {
-    await expect(page.getByRole('row', { name: 'Expand current row' }).first()).toBeVisible({ timeout: 15000 });
+  await test.step("Then I should see the patient's prescription in the table", async () => {
+    await expect(patientRow).toBeVisible({ timeout: 15000 });
   });
 
   await test.step('And I expand the prescription row', async () => {
-    await page.getByRole('row', { name: 'Expand current row' }).getByLabel('Expand current row').first().click();
+    await patientRow.getByLabel('Expand current row').click();
   });
 
   await test.step('And I navigate to the History and comments tab', async () => {
     await page.getByRole('tab', { name: 'History and comments' }).click();
-    await expect(page.getByText('QUANTITY 5 Tablet')).toBeVisible();
+    await expect(historyTabPanel.getByText('QUANTITY 5 Tablet')).toBeVisible();
   });
 
   await test.step('And I edit the dispense record', async () => {
-    await page.getByLabel('History and comments').getByRole('button', { name: 'Options' }).click();
+    await historyTabPanel.getByRole('button', { name: 'Options' }).click();
     await page.getByRole('menuitem', { name: 'Edit Record' }).click();
   });
 
@@ -97,7 +99,7 @@ test('Edit medication dispense', async ({ page }) => {
   });
 
   await test.step('And the quantity should be updated to 9', async () => {
-    await expect(page.getByText('QUANTITY 9 Tablet')).toBeVisible();
+    await expect(historyTabPanel.getByText('QUANTITY 9 Tablet')).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
Add automated testing for editing a dispense event in the pharmacy app. This test will ensure that a dispense event can be edited if it was created in error. 
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://openmrs.atlassian.net/browse/O3-4868

## Other
<!-- Anything not covered above -->
