### PR TITLE
(fix) O3-4956: Completed medication order should update the fulfiller status

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -850,7 +850,6 @@ describe('Util Tests', () => {
       newMedicationDispense.extension[0].valueDateTime = '2023-01-03T14:00:00-05:00';
       newMedicationDispense.whenHandedOver = '2023-01-03T14:00:00-05:00';
       newMedicationDispense.whenPrepared = '2023-01-03T14:00:00-05:00';
-      newMedicationDispense.status = MedicationDispenseStatus.completed;
       newMedicationDispense.quantity.value = 30;
       expect(
         computeNewFulfillerStatusAfterDispenseEvent(
@@ -889,7 +888,7 @@ describe('Util Tests', () => {
 
     test('when adding new dispense should return null if total dispensed less than total ordered and restrict total quantity dispensed config is true', () => {
       newMedicationDispense.extension[0].valueDateTime = '2023-01-03T14:00:00-05:00';
-      newMedicationDispense.status = MedicationDispenseStatus.completed;
+      newMedicationDispense.status = null;
       newMedicationDispense.quantity.value = 20;
       expect(
         computeNewFulfillerStatusAfterDispenseEvent(
@@ -934,10 +933,10 @@ describe('Util Tests', () => {
 
     test('when adding new dispense to request with existing dispense should return null if does not meet total quantiy order and  restrict total quantity dispensed config is true', () => {
       newMedicationDispense.extension[0].valueDateTime = '2023-01-03T14:00:00-05:00';
-      newMedicationDispense.status = MedicationDispenseStatus.completed;
       newMedicationDispense.quantity.value = 10;
+      newMedicationDispense.status = null;
       existingMedicationDispense.extension[0].valueDateTime = '2023-01-03T14:00:00-05:00';
-      existingMedicationDispense.status = MedicationDispenseStatus.completed;
+      existingMedicationDispense.status = null;
       existingMedicationDispense.quantity.value = 10;
       expect(
         computeNewFulfillerStatusAfterDispenseEvent(
@@ -953,7 +952,6 @@ describe('Util Tests', () => {
 
     test('when editing existing dispense should return null if does not meet total quantity order and  restrict total quantity dispensed config is true', () => {
       existingMedicationDispense.extension[0].valueDateTime = '2023-01-03T14:00:00-05:00';
-      existingMedicationDispense.status = MedicationDispenseStatus.completed;
       existingMedicationDispense.quantity.value = 30;
       const editedExistingMedicationDispense = {
         ...existingMedicationDispense,
@@ -973,7 +971,6 @@ describe('Util Tests', () => {
 
     test('when editing existing dispense should return complete if meets total quantity order and  restrict total quantity dispensed config is true', () => {
       existingMedicationDispense.extension[0].valueDateTime = '2023-01-03T14:00:00-05:00';
-      existingMedicationDispense.status = MedicationDispenseStatus.completed;
       existingMedicationDispense.quantity.value = 20;
       const editedExistingMedicationDispense = {
         ...existingMedicationDispense,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,6 +53,10 @@ export function computeFulfillerStatus(
     return MedicationRequestFulfillerStatus.on_hold;
   }
 
+  if (mostRecentMedicationDispenseStatus === MedicationDispenseStatus.completed) {
+    return MedicationRequestFulfillerStatus.completed;
+  }
+
   return null;
 }
 /**


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR updates the computeFulfillerStatus function to return `Completed` if the medication dispense has the status completed. This makes it so that the status column on the patient chart's order column gets updated with the status when a medication order is dispensed.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
The reason this is a draft is because I'm a bit confused. Right now, the `fulfillerStatus` is set to `Completed` only if the config `restrictTotalQuantityDispensed` is set to true and the total dispensing quantity amount has been met.  Right now, this means that looking at the order's table on the patient chart, you wouldn't be able to tell if an order has been dispensed (even if it has been dispensed, multiple times). 
I've made a change so that if the most recent medication dispense's status is completed, then we set the `fulfillerStatus` to completed too, but I suspect that might not be the right thing to do here.
