### PR TITLE
(fix) O3-4982:  Cancel Disabled while submitting a form

### DIFF
--- a/src/forms/close-dispense-form.workspace.tsx
+++ b/src/forms/close-dispense-form.workspace.tsx
@@ -176,7 +176,7 @@ const CloseDispenseForm: React.FC<CloseDispenseFormProps> = ({
         </section>
       </div>
       <section className={styles.buttonGroup}>
-        <Button disabled={isSubmitting} onClick={() => closeWorkspace()} kind="secondary">
+        <Button onClick={() => closeWorkspace()} kind="secondary">
           {getCoreTranslation('cancel', 'Cancel')}
         </Button>
         <Button disabled={!isValid || isSubmitting} onClick={handleSubmit}>

--- a/src/forms/dispense-form.workspace.tsx
+++ b/src/forms/dispense-form.workspace.tsx
@@ -252,7 +252,7 @@ const DispenseForm: React.FC<DispenseFormProps> = ({
         </section>
       </div>
       <section className={styles.buttonGroup}>
-        <Button disabled={isSubmitting} onClick={() => closeWorkspace()} kind="secondary">
+        <Button onClick={() => closeWorkspace()} kind="secondary">
           {getCoreTranslation('cancel', 'Cancel')}
         </Button>
         <Button disabled={isButtonDisabled} onClick={handleSubmit}>

--- a/src/forms/pause-dispense-form.workspace.tsx
+++ b/src/forms/pause-dispense-form.workspace.tsx
@@ -176,7 +176,7 @@ const PauseDispenseForm: React.FC<PauseDispenseFormProps> = ({
         </section>
       </div>
       <section className={styles.buttonGroup}>
-        <Button disabled={isSubmitting} onClick={() => closeWorkspace()} kind="secondary">
+        <Button onClick={() => closeWorkspace()} kind="secondary">
           {getCoreTranslation('cancel', 'Cancel')}
         </Button>
         <Button disabled={!isValid || isSubmitting} onClick={handleSubmit}>


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
In the Close, Pause, Dispense components, clicking the Save button disables the Cancel button because both buttons relied on the isSubmitting state. I therefore removed the disabled={isSubmitting} prop from the Cancel button, so it remains clickable during submission.

## Screenshots
<!-- Required if you are making UI changes. -->

**Before making changes:**


https://github.com/user-attachments/assets/627853ba-95f3-4aa4-9eeb-88d958d45486

**After fixing the issue:** 

https://github.com/user-attachments/assets/671b22ff-2e7c-4f13-8fa3-66b7ee9eddd0

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4982

## Other
<!-- Anything not covered above -->
