### PR TITLE
(fix) O3-4984 Display Today's Date instead of "Today" in dispensing app

### DIFF
--- a/src/pharmacy-header/pharmacy-header.component.tsx
+++ b/src/pharmacy-header/pharmacy-header.component.tsx
@@ -27,7 +27,7 @@ export const PharmacyHeader: React.FC = () => {
           <span className={styles.value}>{userLocation}</span>
           <span className={styles.middot}>&middot;</span>
           <Calendar size={16} />
-          <span className={styles.value}>{formatDate(new Date(), { mode: 'standard' })}</span>
+          <span className={styles.value}>{formatDate(new Date(), { noToday: true })}</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Changed the option: From { mode: 'standard' } to { noToday: true }
The noToday: true option tells the formatDate function to always display the actual date instead of converting it to relative text like "today". Just like it has always been
## Screenshots
<!-- Required if you are making UI changes. -->
## BEFORE:
<img width="1917" height="592" alt="Todays_Date Before" src="https://github.com/user-attachments/assets/e6e3e0ce-6be8-42c9-bd90-3488eee0acde" />
 
## THEN AFTER:
<img width="1920" height="1042" alt="Todays_Date After" src="https://github.com/user-attachments/assets/edf25b70-4d5a-4802-b7cc-d1d067b75d3d" />

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[https://openmrs.atlassian.net/issues/?filter=-4&selectedIssue=O3-4984](https://openmrs.atlassian.net/issues/?filter=-4&selectedIssue=O3-4984)

## Other
<!-- Anything not covered above -->
@fiona855 ,