### PR TITLE
(docs) O3-5012: Clarify yarn start behavior in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,19 +52,23 @@ Note that following privileges need to be installed and assigned to roles:
 
 ## Running this code
 
+First, install dependencies:
+
 ```sh
-yarn  # to install dependencies
-
-# You can start the microfrontend by running `yarn start`.
-# By default, this will proxy requests to `https://dev3.openmrs.org`.
-yarn start
-
-# If you want to run against a local OpenMRS server, you can specify the backend URL and port:
-yarn start --backend "http://localhost:8080/" --port 8081 # will run against a local OpenMRS server at localhost:8080, serving the frontend from 8081
+yarn
 ```
 
-Open a browser, pointing to the port indicated above (eg. 8081):
-`http://localhost:8081/openmrs/spa/dispensing`
+Start the microfrontend by running `yarn start`. By default, this will proxy requests to the demo O3 server at `https://dev3.openmrs.org`.
+
+If you want to run against a different OpenMRS server, you can specify the backend URL and port using the optional `--backend` and `--port` CLI arguments:
+
+```sh
+yarn start --backend "http://localhost:8080/" --port 8081
+```
+
+This will start the microfrontend at `http://localhost:8081/openmrs/spa`. Log in and navigate to `/openmrs/spa/dispensing` to access the Dispensing app. Alternatively, once on the home page, you can click on the App menu icon in the top right corner of the navbar and select "Dispensing".
+
+Note: All backend requests will be proxied to your local OpenMRS instance running on `http://localhost:8080/`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
### Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This pull request updates the `README.md` to clarify the usage of the `yarn start` command.

Previously, the documentation only demonstrated the command with arguments for connecting to a local backend, which could be confusing for new contributors. The updated instructions now explain that:

* Running `yarn start` without arguments is valid.
* By default, requests are proxied to **[https://dev3.openmrs.org/](https://dev3.openmrs.org)**.
* The use can specify optional CLI arguments to specify an alternative backend server to run the app against. Read more about this [here](https://openmrs.atlassian.net/wiki/spaces/docs/pages/150962685/Develop+Frontend+Modules#Running-frontend-modules-locally). 

This change makes it easier for new contributors to quickly get the project up and running without additional configuration.

## Screenshots

## Related Issue
[O3-5012](https://openmrs.atlassian.net/browse/O3-5012)

## Other

[O3-5012]: https://openmrs.atlassian.net/browse/O3-5012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ