### PR TITLE
(feat) O3-5497: Enable a facility location to accept multiple Associated Pharmacy Locations.

### DIFF
--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -72,6 +72,16 @@ export const configSchema = {
         _description: 'Name of the attribute used to associate locations with a pharmacy location',
         _default: 'Associated Pharmacy Location',
       },
+      useAssociatedPharmacyLocations: {
+        _type: Type.Boolean,
+        _description: 'Show medication requests from all associated pharmacy locations of the current location',
+        _default: false,
+      },
+      useCurrentLocation: {
+        _type: Type.Boolean,
+        _description: 'Show medication requests from current location',
+        _default: false,
+      },
     },
   },
   refreshInterval: {
@@ -168,6 +178,8 @@ export interface PharmacyConfig {
       enabled: boolean;
       tag: string;
       associatedPharmacyLocationAttribute: string;
+      useAssociatedPharmacyLocations: boolean;
+      useCurrentLocation: boolean;
     };
   };
   valueSets: {

--- a/src/location/location.resource.test.tsx
+++ b/src/location/location.resource.test.tsx
@@ -28,6 +28,8 @@ const pharmacyConfig: PharmacyConfig = {
       enabled: false,
       tag: 'Login Location',
       associatedPharmacyLocationAttribute: 'Associated Pharmacy Location',
+      useAssociatedPharmacyLocations: true,
+      useCurrentLocation: true,
     },
   },
   refreshInterval: 10000,
@@ -79,11 +81,37 @@ describe('Location Resource tests', () => {
                 uuid: '84b9b680-786c-4388-9e7c-805614c13b5a',
               },
             },
+            {
+              attributeType: {
+                name: 'Associated Pharmacy Location',
+              },
+              value: {
+                uuid: '318bb1dc-77e3-4ac4-b524-cef0e8a456bd',
+              },
+            },
+            {
+              attributeType: {
+                name: 'Associated Pharmacy Location',
+              },
+              value: {
+                uuid: '879bf321-e857-43a5-8f6b-e28e345a34c1',
+              },
+            },
           ],
         },
         {
           uuid: '7b959d2f-11f3-4611-b2e4-700200625d61',
           name: 'KGH NCD',
+          attributes: [],
+        },
+        {
+          uuid: '318bb1dc-77e3-4ac4-b524-cef0e8a456bd',
+          name: 'KGH MCH Main Pharmacy',
+          attributes: [],
+        },
+        {
+          uuid: '879bf321-e857-43a5-8f6b-e28e345a34c1',
+          name: 'KGH MCH Revolving Fund Pharmacy',
           attributes: [],
         },
       ],
@@ -93,16 +121,22 @@ describe('Location Resource tests', () => {
     useSWR.mockImplementation(() => ({ data: { data: queryResultsBundle } }));
     const { result } = renderHook(() => useLocations(pharmacyConfig));
     const { locations } = result.current;
-    expect(locations.length).toBe(3);
+    expect(locations.length).toBe(5);
     // should be sorted by name alphabetically
     expect(locations[0].id).toBe('5981f962-6eec-453d-89ce-2f9ac48d096f');
     expect(locations[0].name).toBe('KGH MCH');
-    expect(locations[0].associatedPharmacyLocation).toBe('84b9b680-786c-4388-9e7c-805614c13b5a');
-    expect(locations[1].id).toBe('7b959d2f-11f3-4611-b2e4-700200625d61');
-    expect(locations[1].name).toBe('KGH NCD');
-    expect(locations[1].associatedPharmacyLocation).toBe(null);
-    expect(locations[2].id).toBe('2bcb9215-8cd6-11eb-b7be-0242ac110002');
-    expect(locations[2].name).toBe('KGH Triage');
-    expect(locations[2].associatedPharmacyLocation).toBe(null);
+    expect(locations[0].associatedPharmacyLocations).toContain('84b9b680-786c-4388-9e7c-805614c13b5a');
+    expect(locations[1].id).toBe('318bb1dc-77e3-4ac4-b524-cef0e8a456bd');
+    expect(locations[1].name).toBe('KGH MCH Main Pharmacy');
+    expect(locations[1].associatedPharmacyLocations).toEqual([]);
+    expect(locations[2].id).toBe('879bf321-e857-43a5-8f6b-e28e345a34c1');
+    expect(locations[2].name).toBe('KGH MCH Revolving Fund Pharmacy');
+    expect(locations[2].associatedPharmacyLocations).toEqual([]);
+    expect(locations[3].id).toBe('7b959d2f-11f3-4611-b2e4-700200625d61');
+    expect(locations[3].name).toBe('KGH NCD');
+    expect(locations[3].associatedPharmacyLocations).toEqual([]);
+    expect(locations[4].id).toBe('2bcb9215-8cd6-11eb-b7be-0242ac110002');
+    expect(locations[4].name).toBe('KGH Triage');
+    expect(locations[4].associatedPharmacyLocations).toEqual([]);
   });
 });

--- a/src/location/location.resource.tsx
+++ b/src/location/location.resource.tsx
@@ -16,10 +16,13 @@ export function useLocations(config: PharmacyConfig) {
       ?.map((e) => ({
         id: e.uuid,
         name: e.name,
-        associatedPharmacyLocation:
-          e.attributes?.find(
-            (a) => a.attributeType.name === config.locationBehavior.locationFilter.associatedPharmacyLocationAttribute,
-          )?.value?.uuid ?? null,
+        associatedPharmacyLocations:
+          e.attributes
+            ?.filter(
+              (a) =>
+                a.attributeType.name === config.locationBehavior.locationFilter.associatedPharmacyLocationAttribute,
+            )
+            ?.map((a) => a.value.uuid) ?? [],
       }))
       .sort((a, b) => a.name.localeCompare(b.name));
   }, [data?.data?.results, config]);

--- a/src/prescriptions/prescription-tab-panel.component.tsx
+++ b/src/prescriptions/prescription-tab-panel.component.tsx
@@ -31,10 +31,31 @@ const PrescriptionTabPanel: React.FC<PrescriptionTabPanelProps> = ({
   // set any initially selected locations
   useEffect(() => {
     if (!isInitialized.current && !isFilterLocationsLoading && sessionLocation?.uuid) {
-      setFilterLocations(locations?.filter((l) => sessionLocation?.uuid === l.associatedPharmacyLocation) || []);
+      const initialLocations: SimpleLocation[] = [];
+      // Should display from the location associated with the pharmacy location
+      initialLocations.push(
+        ...(locations?.filter((l) => l.associatedPharmacyLocations?.includes(sessionLocation?.uuid)) || []),
+      );
+
+      // Should display from all the associated pharmacy locations of the current location
+      if (config.locationBehavior.locationFilter.useAssociatedPharmacyLocations) {
+        initialLocations.push(
+          ...(locations?.filter((v) =>
+            locations?.find((l) => l.id === sessionLocation?.uuid).associatedPharmacyLocations?.includes(v.id),
+          ) || []),
+        );
+      }
+
+      // Should display from current location
+      if (config.locationBehavior.locationFilter.useCurrentLocation) {
+        initialLocations.push(...(locations?.filter((l) => l.id === sessionLocation?.uuid) || []));
+      }
+
+      setFilterLocations(initialLocations || []);
+
       isInitialized.current = true; // we only want to run when the component is first mounted so we don't override user changes
     }
-  }, [isFilterLocationsLoading, sessionLocation, locations]);
+  }, [isFilterLocationsLoading, sessionLocation, locations, config]);
 
   return (
     <TabPanel>

--- a/src/types.ts
+++ b/src/types.ts
@@ -461,7 +461,7 @@ export interface Reference {
 export interface SimpleLocation {
   id: string;
   name: string;
-  associatedPharmacyLocation?: string;
+  associatedPharmacyLocations?: Array<string>;
 }
 
 export interface ValueSet {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Currently, the Associated Pharmacy Location can only accept one location. This PR enables application of several associated pharmacy locations. Given a scenario where we have a facility named KGH, it can have two or more associated pharmacies i.e, 1. KGH Revolving Pharmacy and 2. KGH Main Pharmacy. Now from KGH location, we can filter either by the current location or by the associated pharmacy locations. 
We are also introducing two config properties namely: 

1. useAssociatedPharmacyLocations - For showing medication requests from all associated pharmacy locations of the current location.
2. useCurrentLocation - For showing medication requests from the current location.

## Screenshots
<!-- Required if you are making UI changes. -->
a. Without current location filter:
<img width="1927" height="878" alt="image" src="https://github.com/user-attachments/assets/33e57e84-887d-46e9-91b9-b406af0e185e" />
b. With current location filter:
<img width="1927" height="710" alt="image" src="https://github.com/user-attachments/assets/433558d3-38f4-4858-b349-e340976839fa" />


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
