### PR TITLE
(chore) Bump CI actions to Node.js 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
@@ -90,7 +90,7 @@ jobs:
 
     steps:
       - name: Trigger RefApp Build
-        uses: fjogeleit/http-request-action@master
+        uses: fjogeleit/http-request-action@v2
         with:
           url: https://ci.openmrs.org/rest/api/latest/queue/O3-BF
           method: "POST"


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary

GitHub is deprecating Node.js 20 for JavaScript actions. Node 24 becomes the default on June 2nd, 2026 and Node 20 is removed from runners on September 16th, 2026. The `pre_release` and `deploy` jobs currently emit deprecation warnings because `actions/download-artifact@v4` and `fjogeleit/http-request-action@master` still ship a Node 20 runtime.

Changes to `.github/workflows/ci.yml`:

- `actions/download-artifact@v4` → `@v7`. v7 is the first release that runs on Node 24 by default. Skipping v8 avoids its new hash-mismatch-as-error default. The current usage downloads all artifacts with no `name`/`id` filter, so v5's single-artifact path fix does not affect us.
- `fjogeleit/http-request-action@master` → `@v2`. v2.0.0's only change is the Node 16 → Node 24 runtime bump; the input API (`url`, `method`, `customHeaders`) is unchanged. Also drops the unsafe `@master` pin.

## Screenshots

N/A

## Related Issue

N/A.

## Other

Follow-up to the Node 20 deprecation warnings observed on the `pre_release` and `deploy` jobs of recent `main` builds.