### PR TITLE
(fix) O3-5632: Make on-prescription-filled modal not enable button unt…

### DIFF
--- a/src/fill-prescription/on-prescription-filled.modal.tsx
+++ b/src/fill-prescription/on-prescription-filled.modal.tsx
@@ -46,7 +46,7 @@ const OnPrescriptionFilledModal: React.FC<OnPrescriptionFilledModalProps> = ({ p
   const { dispenserProviderRoles } = useConfig<PharmacyConfig>();
   const session = useSession();
   const providers = useProviders(dispenserProviderRoles);
-  const { medicationRequestBundles } = usePrescriptionDetails(encounterUuid);
+  const { medicationRequestBundles, isLoading: isLoadingPrescriptionDetails } = usePrescriptionDetails(encounterUuid);
   const { t } = useTranslation();
   const [isSubmitting, setIsSubmitting] = React.useState(false);
 
@@ -126,7 +126,7 @@ const OnPrescriptionFilledModal: React.FC<OnPrescriptionFilledModalProps> = ({ p
           {t('createOrderWithoutDispensing', 'Create order without dispensing')}
         </Button>
         <Button
-          disabled={isSubmitting}
+          disabled={isSubmitting || isLoadingPrescriptionDetails}
           onClick={() => {
             onConfirm();
           }}>


### PR DESCRIPTION
…il it finishes fetching data

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
See JIRA ticket. If the user clicks the "Dispense all prescriptions" button in the modal before the prescription data is loaded, then the button does nothing. Fixed by disabling that button until the data is loaded.

Bug shows up as intermittent failures in our E2E tests. 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://issues.openmrs.org/browse/O3-5632

## Other
<!-- Anything not covered above -->
