### PR TITLE
(fix) O3-5630: Fix substitution type and reason not populated when ed…

### DIFF
--- a/src/forms/dispense-form.workspace.tsx
+++ b/src/forms/dispense-form.workspace.tsx
@@ -69,7 +69,7 @@ const DispenseForm: React.FC<Workspace2DefinitionProps<DispenseFormProps, {}, {}
   const [inventoryItem, setInventoryItem] = useState<InventoryItem>();
 
   // Keep track of medication dispense payload
-  const [medicationDispensePayload, setMedicationDispensePayload] = useState<MedicationDispense>();
+  const [medicationDispensePayload, setMedicationDispensePayload] = useState(medicationDispense);
 
   // to prevent duplicate submits
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -293,9 +293,6 @@ const DispenseForm: React.FC<Workspace2DefinitionProps<DispenseFormProps, {}, {}
           medicationDispensePayload.substitution.type?.coding[0].code))
     );
   }, [isFreeTextDosage, medicationDispensePayload, quantityRemaining]);
-
-  // initialize the internal dispense payload with the dispenses passed in as props
-  useEffect(() => setMedicationDispensePayload(medicationDispense), [medicationDispense]);
 
   // Auto-default "Complete Order With This Dispense" checkbox for orders with no refills
   useEffect(() => {

--- a/src/forms/medication-dispense-review.component.tsx
+++ b/src/forms/medication-dispense-review.component.tsx
@@ -60,7 +60,7 @@ const MedicationDispenseReview: React.FC<MedicationDispenseReviewProps> = ({
   // ordered; it's slightly inefficient/awkward to fetch it from the server here because we *have* fetched it earlier,
   // it just seems cleaner to fetch it here rather than to make sure we pass it down through various components; with
   // SWR handling caching, we may want to consider pulling more down into this)
-  const { medicationRequest } = useMedicationRequest(
+  const { medicationRequest, isLoading: isMedicationRequestLoading } = useMedicationRequest(
     medicationDispense.authorizingPrescription ? medicationDispense.authorizingPrescription[0].reference : null,
     config.refreshInterval,
   );
@@ -147,6 +147,9 @@ const MedicationDispenseReview: React.FC<MedicationDispenseReviewProps> = ({
 
   const { substitution } = medicationDispense;
   useEffect(() => {
+    if (isMedicationRequestLoading) {
+      return;
+    }
     if (isSubstitution) {
       // make sure that the value substitution.wasSubstituted exists and is truthy
       if (!substitution.wasSubstituted) {
@@ -158,7 +161,7 @@ const MedicationDispenseReview: React.FC<MedicationDispenseReviewProps> = ({
         updateMedicationDispense({ substitution: blankSubstitution });
       }
     }
-  }, [isSubstitution, substitution, updateMedicationDispense]);
+  }, [isMedicationRequestLoading, isSubstitution, substitution, updateMedicationDispense]);
 
   useEffect(() => {
     setUserCanModify(session?.user && userHasAccess(PRIVILEGE_CREATE_DISPENSE_MODIFY_DETAILS, session.user));

--- a/src/medication-request/medication-request.resource.tsx
+++ b/src/medication-request/medication-request.resource.tsx
@@ -224,13 +224,14 @@ export function useMedicationRequest(reference: string, refreshInterval) {
       : `MedicationRequest/${reference}`
     : null;
 
-  const { data } = useSWR<{ data: MedicationRequest }, Error>(
+  const { data, isLoading } = useSWR<{ data: MedicationRequest }, Error>(
     reference ? `${fhirBaseUrl}/${reference}` : null,
     openmrsFetch,
     { refreshInterval: refreshInterval },
   );
   return {
     medicationRequest: data ? data.data : null,
+    isLoading,
   };
 }
 


### PR DESCRIPTION
…iting a dispense record

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
For a dispense record that's been edited with a drug substitution, when we reload the dispensing app and try to edit the record again, the "substitution type" and "substitution reason" fields are not populated correctly. This PR fixes that.

## Screenshots
<!-- Required if you are making UI changes. -->
Before:
https://github.com/user-attachments/assets/2e8cfb28-ef6c-4f76-906a-5d38d4991187

After:
https://github.com/user-attachments/assets/667c28aa-5a7d-46b3-963f-05d357f78c5e



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3-5630 -->
https://issues.openmrs.org/browse/O3-5630

## Other
<!-- Anything not covered above -->
