### PR TITLE
(feat) O3-5650: Add config to limit location filter options by visit location

### DIFF
--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -87,13 +87,20 @@ export const configSchema = {
       },
       tag: {
         _type: Type.String,
-        _description: 'Name of the location tag to use when fetching locations to populate filter',
+        _description: 'Only locations with this tag will appear as options in the location dropdown filter',
         _default: 'Login Location',
       },
       associatedPharmacyLocationAttribute: {
         _type: Type.String,
-        _description: 'Name of the attribute used to associate locations with a pharmacy location',
+        _description:
+          "Name of the location attribute whose value identifies the associated pharmacy location. The location whose attribute value matches the user's login location will be pre-selected in the filter dropdown. This attribute has no effect on which locations appear as options.",
         _default: 'Associated Pharmacy Location',
+      },
+      restrictToVisitLocationDescendants: {
+        _type: Type.Boolean,
+        _description:
+          "If true, further restricts the dropdown options to locations that are descendants of the current login location's nearest ancestor tagged as a visit location. Requires the EMR API module to be installed.",
+        _default: false,
       },
     },
   },
@@ -197,6 +204,7 @@ export interface PharmacyConfig {
       enabled: boolean;
       tag: string;
       associatedPharmacyLocationAttribute: string;
+      restrictToVisitLocationDescendants: boolean;
     };
   };
   valueSets: {

--- a/src/location/location.resource.test.tsx
+++ b/src/location/location.resource.test.tsx
@@ -1,9 +1,12 @@
 import useSWR from 'swr';
-import { vi, describe, expect, test } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import { renderHook } from '@testing-library/react';
-import { openmrsFetch } from '@openmrs/esm-framework';
-import { useLocations } from './location.resource';
+import { openmrsFetch, useFeatureFlag, useSession } from '@openmrs/esm-framework';
+import { MissingOptionalBackendDependencyError, useLocations } from './location.resource';
 import { type PharmacyConfig } from '../config-schema';
+
+const mockUseFeatureFlag = vi.mocked(useFeatureFlag);
+const mockUseSession = vi.mocked(useSession);
 
 vi.mocked(openmrsFetch);
 vi.mock('swr');
@@ -33,6 +36,7 @@ const pharmacyConfig: PharmacyConfig = {
       enabled: false,
       tag: 'Login Location',
       associatedPharmacyLocationAttribute: 'Associated Pharmacy Location',
+      restrictToVisitLocationDescendants: false,
     },
   },
   refreshInterval: 10000,
@@ -52,8 +56,8 @@ const pharmacyConfig: PharmacyConfig = {
   duplicateCheckWindowDays: 0,
 };
 
-describe('Location Resource tests', () => {
-  test('useLoginLocations should call proper endpoint via SWR', () => {
+describe('useLocations', () => {
+  it('should call proper endpoint via SWR', () => {
     // @ts-ignore
     useSWR.mockImplementation(() => ({
       data: { data: 'mockedLoginLocations' },
@@ -61,11 +65,11 @@ describe('Location Resource tests', () => {
 
     renderHook(() => useLocations(pharmacyConfig));
     expect(useSWR).toHaveBeenCalledWith(
-      '/ws/rest/v1/location?tag=Login%20Location&v=custom:(uuid,name,attributes:(attributeType:(name),value:(uuid))',
+      '/ws/rest/v1/location?tag=Login%20Location&v=custom:(uuid,name,attributes:(attributeType:(name),value:(uuid)))',
       openmrsFetch,
     );
   });
-  test('useLoginLocations should parse into Login Locations Array', () => {
+  it('should parse into Locations Array', () => {
     // @ts-ignore
     const queryResultsBundle = {
       results: [
@@ -111,5 +115,82 @@ describe('Location Resource tests', () => {
     expect(locations[2].id).toBe('2bcb9215-8cd6-11eb-b7be-0242ac110002');
     expect(locations[2].name).toBe('KGH Triage');
     expect(locations[2].associatedPharmacyLocation).toBe(null);
+  });
+
+  describe('when restrictToVisitLocationDescendants is true', () => {
+    const visitLocationConfig: PharmacyConfig = {
+      ...pharmacyConfig,
+      locationBehavior: {
+        ...pharmacyConfig.locationBehavior,
+        locationFilter: {
+          ...pharmacyConfig.locationBehavior.locationFilter,
+          restrictToVisitLocationDescendants: true,
+        },
+      },
+    };
+
+    it('returns MissingOptionalBackendDependencyError when emrapi is not installed', () => {
+      mockUseFeatureFlag.mockReturnValue(false);
+      // @ts-ignore
+      useSWR.mockReturnValue({ data: null });
+
+      const { result } = renderHook(() => useLocations(visitLocationConfig));
+      expect(result.current.error).toBeInstanceOf(MissingOptionalBackendDependencyError);
+    });
+
+    it('calls the emrapi endpoint when emrapi is installed and session location is set', () => {
+      mockUseFeatureFlag.mockReturnValue(true);
+      // @ts-ignore
+      mockUseSession.mockReturnValue({ sessionLocation: { uuid: 'session-location-uuid' } });
+      // @ts-ignore
+      useSWR.mockReturnValue({ data: null });
+
+      renderHook(() => useLocations(visitLocationConfig));
+      expect(useSWR).toHaveBeenCalledWith(
+        '/ws/rest/v1/emrapi/locationThatSupportsVisits?location=session-location-uuid&v=custom:(uuid,name,descendantLocations:(uuid,name,tags,attributes:(attributeType:(name),value:(uuid))))',
+        openmrsFetch,
+      );
+    });
+
+    it('returns descendant locations filtered by tag and sorted by name', () => {
+      // @ts-ignore
+      mockUseSession.mockReturnValue({ sessionLocation: { uuid: 'session-location-uuid' } });
+      const queryResultsBundle = {
+        descendantLocations: [
+          {
+            uuid: 'loc-1',
+            name: 'KGH Triage',
+            tags: [{ display: 'Login Location' }],
+            attributes: [],
+          },
+          {
+            uuid: 'loc-2',
+            name: 'KGH MCH',
+            tags: [{ display: 'Login Location' }],
+            attributes: [{ attributeType: { name: 'Associated Pharmacy Location' }, value: { uuid: 'pharm-uuid' } }],
+          },
+          {
+            uuid: 'loc-3',
+            name: 'KGH Admin',
+            tags: [{ display: 'Some Other Tag' }],
+            attributes: [],
+          },
+        ],
+      };
+      // @ts-ignore
+      useSWR.mockReturnValue({ data: { data: queryResultsBundle } });
+
+      const { result } = renderHook(() => useLocations(visitLocationConfig));
+      const { locations } = result.current;
+
+      // loc-3 is filtered out because it doesn't have the 'Login Location' tag
+      expect(locations.length).toBe(2);
+      expect(locations[0].id).toBe('loc-2');
+      expect(locations[0].name).toBe('KGH MCH');
+      expect(locations[0].associatedPharmacyLocation).toBe('pharm-uuid');
+      expect(locations[1].id).toBe('loc-1');
+      expect(locations[1].name).toBe('KGH Triage');
+      expect(locations[1].associatedPharmacyLocation).toBe(null);
+    });
   });
 });

--- a/src/location/location.resource.tsx
+++ b/src/location/location.resource.tsx
@@ -1,32 +1,93 @@
 import useSWR from 'swr';
-import { type FetchResponse, openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
+import {
+  type FetchResponse,
+  type Location,
+  openmrsFetch,
+  restBaseUrl,
+  useFeatureFlag,
+  useSession,
+} from '@openmrs/esm-framework';
 import { type SimpleLocation } from '../types';
 import { type PharmacyConfig } from '../config-schema';
 import { useMemo } from 'react';
 
+export class MissingOptionalBackendDependencyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MissingOptionalBackendDependencyError';
+  }
+}
+
+/**
+ * Returns the list of locations to show in the location filter dropdown, based on the configuration. If the
+ * restrictToVisitLocationDescendants option is enabled, only returns locations that are descendants of the current login
+ * location's nearest ancestor tagged as a visit location.
+ * Location options are further filtered with the tag specified in the configuration.
+ */
 export function useLocations(config: PharmacyConfig) {
-  const { data, error } = useSWR<FetchResponse, Error>(
-    `${restBaseUrl}/location?tag=${encodeURIComponent(config.locationBehavior.locationFilter.tag)}&v=custom:(uuid,name,attributes:(attributeType:(name),value:(uuid))`,
-    openmrsFetch,
+  const { restrictToVisitLocationDescendants } = config.locationBehavior.locationFilter;
+  const byTag = useLocationsByTag(config, !restrictToVisitLocationDescendants);
+  const byVisit = useVisitLocationDescendants(config, restrictToVisitLocationDescendants);
+  return restrictToVisitLocationDescendants ? byVisit : byTag;
+}
+
+function toSimpleLocation(associatedPharmacyLocationAttribute: string) {
+  return (e: Location): SimpleLocation => ({
+    id: e.uuid,
+    name: e.name,
+    associatedPharmacyLocation:
+      e.attributes?.find((a) => a.attributeType.name === associatedPharmacyLocationAttribute)?.value?.uuid ?? null,
+  });
+}
+
+function useLocationsByTag(config: PharmacyConfig, enabled: boolean) {
+  const { tag, associatedPharmacyLocationAttribute } = config.locationBehavior.locationFilter;
+  const url = enabled
+    ? `${restBaseUrl}/location?tag=${encodeURIComponent(tag)}&v=custom:(uuid,name,attributes:(attributeType:(name),value:(uuid)))`
+    : null;
+  const { data, ...rest } = useSWR<FetchResponse<{ results: Location[] }>>(url, openmrsFetch);
+
+  const locations = useMemo(
+    () =>
+      (data?.data?.results ?? [])
+        .map(toSimpleLocation(associatedPharmacyLocationAttribute))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [data, associatedPharmacyLocationAttribute],
   );
 
-  // parse down to a simple representation of locations
-  const locations: Array<SimpleLocation> = useMemo(() => {
-    return data?.data?.results
-      ?.map((e) => ({
-        id: e.uuid,
-        name: e.name,
-        associatedPharmacyLocation:
-          e.attributes?.find(
-            (a) => a.attributeType.name === config.locationBehavior.locationFilter.associatedPharmacyLocationAttribute,
-          )?.value?.uuid ?? null,
-      }))
-      .sort((a, b) => a.name.localeCompare(b.name));
-  }, [data?.data?.results, config]);
+  return { locations, ...rest };
+}
 
-  return {
-    locations,
-    error,
-    isLoading: !locations && !error,
-  };
+function useVisitLocationDescendants(config: PharmacyConfig, enabled: boolean) {
+  const { sessionLocation } = useSession();
+  const { tag, associatedPharmacyLocationAttribute } = config.locationBehavior.locationFilter;
+  const isEMRAPIInstalled = useFeatureFlag('emrapi-module');
+
+  const configError = useMemo(
+    () =>
+      enabled && !isEMRAPIInstalled
+        ? new MissingOptionalBackendDependencyError(
+            'The restrictToVisitLocationDescendants option is enabled in the configuration, but the EMR API module is not installed.',
+          )
+        : null,
+    [enabled, isEMRAPIInstalled],
+  );
+
+  const url =
+    enabled && !configError && sessionLocation?.uuid
+      ? `${restBaseUrl}/emrapi/locationThatSupportsVisits?location=${sessionLocation.uuid}&v=custom:(uuid,name,descendantLocations:(uuid,name,tags,attributes:(attributeType:(name),value:(uuid))))`
+      : null;
+  const { data, ...rest } = useSWR<FetchResponse<{ descendantLocations: Location[] }>>(url, openmrsFetch);
+
+  const locations = useMemo(
+    () =>
+      (data?.data?.descendantLocations ?? [])
+        // emrapi/locationThatSupportsVisits does not support server-side tag filtering, so we filter client-side
+        .filter((l) => l.tags?.some((t) => t.display === tag))
+        .map(toSimpleLocation(associatedPharmacyLocationAttribute))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [data, tag, associatedPharmacyLocationAttribute],
+  );
+
+  return { locations, ...rest, error: configError ?? rest.error };
 }

--- a/src/prescriptions/prescription-tab-lists.component.tsx
+++ b/src/prescriptions/prescription-tab-lists.component.tsx
@@ -1,9 +1,10 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Tab, Tabs, TabList, TabPanels } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
-import { useConfig, useSession } from '@openmrs/esm-framework';
+import { showSnackbar, useConfig, useSession } from '@openmrs/esm-framework';
 import { type CustomTab } from '../types';
 import { type PharmacyConfig } from '../config-schema';
+import { MissingOptionalBackendDependencyError, useLocations } from '../location/location.resource';
 import PatientSearchTabPanel from './patient-search-tab-panel.component';
 import PrescriptionTabPanel from './prescription-tab-panel.component';
 import styles from './prescriptions.scss';
@@ -12,6 +13,20 @@ const PrescriptionTabLists: React.FC = () => {
   const { t } = useTranslation();
   const config = useConfig<PharmacyConfig>();
   const session = useSession();
+  const { error: locationsError } = useLocations(config);
+
+  useEffect(() => {
+    if (locationsError instanceof MissingOptionalBackendDependencyError) {
+      showSnackbar({
+        kind: 'error',
+        title: t('configurationError', 'Configuration error'),
+        subtitle: t(
+          'locationFilterMisconfigured',
+          'The location filter is misconfigured. Check that the required backend module is installed.',
+        ),
+      });
+    }
+  }, [locationsError, t]);
   const [selectedTab, setSelectedTab] = useState(0);
 
   // filter tabs based on session location

--- a/src/prescriptions/prescription-tab-panel.component.tsx
+++ b/src/prescriptions/prescription-tab-panel.component.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MultiSelect, Search, TabPanel } from '@carbon/react';
-import { useConfig, useDebounce, useSession } from '@openmrs/esm-framework';
+import { showNotification, useConfig, useDebounce, useSession } from '@openmrs/esm-framework';
 import { type PharmacyConfig } from '../config-schema';
 import PrescriptionsTable from './prescriptions-table.component';
 import styles from './prescriptions.scss';
-import { useLocations } from '../location/location.resource';
+import { MissingOptionalBackendDependencyError, useLocations } from '../location/location.resource';
 import { type SimpleLocation } from '../types';
 
 interface PrescriptionTabPanelProps {
@@ -23,15 +23,29 @@ const PrescriptionTabPanel: React.FC<PrescriptionTabPanelProps> = ({
   const config = useConfig<PharmacyConfig>();
   const isInitialized = useRef(false);
   const { sessionLocation } = useSession();
-  const { locations, isLoading: isFilterLocationsLoading } = useLocations(config);
+  const { locations, isLoading: isFilterLocationsLoading, error: locationsError } = useLocations(config);
   const [searchTerm, setSearchTerm] = useState('');
   const debouncedSearchTerm = useDebounce(searchTerm, 500);
   const [filterLocations, setFilterLocations] = useState<SimpleLocation[]>([]);
 
+  useEffect(() => {
+    if (locationsError instanceof MissingOptionalBackendDependencyError) {
+      showNotification({
+        kind: 'error',
+        title: t('configurationError', 'Configuration error'),
+        description: locationsError.message,
+      });
+    }
+  }, [locationsError, t]);
+
   // set any initially selected locations
   useEffect(() => {
     if (!isInitialized.current && !isFilterLocationsLoading && sessionLocation?.uuid) {
-      setFilterLocations(locations?.filter((l) => sessionLocation?.uuid === l.associatedPharmacyLocation) || []);
+      setFilterLocations(
+        locations?.filter((l) => {
+          return sessionLocation?.uuid === l.associatedPharmacyLocation;
+        }) || [],
+      );
       isInitialized.current = true; // we only want to run when the component is first mounted so we don't override user changes
     }
   }, [isFilterLocationsLoading, sessionLocation, locations]);

--- a/src/prescriptions/prescription-tab-panel.component.tsx
+++ b/src/prescriptions/prescription-tab-panel.component.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MultiSelect, Search, TabPanel } from '@carbon/react';
-import { showNotification, useConfig, useDebounce, useSession } from '@openmrs/esm-framework';
+import { useConfig, useDebounce, useSession } from '@openmrs/esm-framework';
 import { type PharmacyConfig } from '../config-schema';
 import PrescriptionsTable from './prescriptions-table.component';
 import styles from './prescriptions.scss';
-import { MissingOptionalBackendDependencyError, useLocations } from '../location/location.resource';
+import { useLocations } from '../location/location.resource';
 import { type SimpleLocation } from '../types';
 
 interface PrescriptionTabPanelProps {
@@ -23,20 +23,10 @@ const PrescriptionTabPanel: React.FC<PrescriptionTabPanelProps> = ({
   const config = useConfig<PharmacyConfig>();
   const isInitialized = useRef(false);
   const { sessionLocation } = useSession();
-  const { locations, isLoading: isFilterLocationsLoading, error: locationsError } = useLocations(config);
+  const { locations, isLoading: isFilterLocationsLoading } = useLocations(config);
   const [searchTerm, setSearchTerm] = useState('');
   const debouncedSearchTerm = useDebounce(searchTerm, 500);
   const [filterLocations, setFilterLocations] = useState<SimpleLocation[]>([]);
-
-  useEffect(() => {
-    if (locationsError instanceof MissingOptionalBackendDependencyError) {
-      showNotification({
-        kind: 'error',
-        title: t('configurationError', 'Configuration error'),
-        description: locationsError.message,
-      });
-    }
-  }, [locationsError, t]);
 
   // set any initially selected locations
   useEffect(() => {

--- a/src/routes.json
+++ b/src/routes.json
@@ -2,7 +2,17 @@
   "$schema": "https://json.openmrs.org/routes.schema.json",
   "backendDependencies": {
     "fhir2": ">=1.2",
-    "webservices.rest": ">=2.2.0"
+    "webservices.rest": ">=3.5.0 <4.0.0"
+  },
+  "optionalBackendDependencies": {
+    "emrapi": {
+      "version": ">=3.3.0 <4.0.0",
+      "feature": {
+        "flagName": "emrapi-module",
+        "label": "EMR API Module",
+        "description": "Required if the locationBehavior.locationFilter.restrictToVisitLocationDescendants config is set to true."
+      }
+    }
   },
   "pages": [
     {

--- a/translations/en.json
+++ b/translations/en.json
@@ -20,6 +20,7 @@
   "completeOrderWithThisDispense": "Complete order with this dispense",
   "conditions": "Condition",
   "conditionsAndDiagnoses": "Conditions and diagnoses",
+  "configurationError": "Configuration error",
   "couldNotDeleteMedicationDispense": "Could not delete medication dispense",
   "couldNotUpdateMedicationRequestStatus": "Could not update medication request status",
   "created": "Created",

--- a/translations/en.json
+++ b/translations/en.json
@@ -81,6 +81,7 @@
   "loading": "Loading prescriptions",
   "loadingInventoryItems": "Loading inventory items...",
   "location": "Location",
+  "locationFilterMisconfigured": "The location filter is misconfigured. Check that the required backend module is installed.",
   "medication": "Medication",
   "medicationDispenseActionMenu": "Medication Dispense Action Menu",
   "medicationDispenseDeleted": "Medication dispense was deleted successfully",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
The dispensing app has a config to allow for filtering the prescriptions table by location. This PR adds a additional config, `restrictToVisitLocationDescendants`. If true, the location dropdown options are restricted to locations that are descendants of the current login location's nearest ancestor tagged as a visit location.

## Screenshots
<!-- Required if you are making UI changes. -->
with `restrictToVisitLocationDescendants` false:
https://github.com/user-attachments/assets/635a7743-9b85-48e2-8e82-4565e88226b3

with `restrictToVisitLocationDescendants` true:
https://github.com/user-attachments/assets/11383378-288c-4a6e-8465-aeb41861571b





## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
