### PR TITLE
(feat) O3-5690: Add extension slot to enable adding print button for a medication dispense

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,4 +21,4 @@ export const PRESCRIPTIONS_TABLE_ENDPOINT = 'Encounter?_query=encountersWithMedi
 
 export const PRESCRIPTION_DETAILS_ENDPOINT = 'MedicationRequest';
 
-export const MEDICATION_DISPENSE_ACTION_MENU_ITEM_SLOT = 'medication-dispense-action-menu-item-slot';
+export const MEDICATION_DISPENSE_ACTION_SLOT = 'medication-dispense-action-slot';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,3 +20,5 @@ export const JSON_MERGE_PATH_MIME_TYPE = 'application/merge-patch+json';
 export const PRESCRIPTIONS_TABLE_ENDPOINT = 'Encounter?_query=encountersWithMedicationRequests';
 
 export const PRESCRIPTION_DETAILS_ENDPOINT = 'MedicationRequest';
+
+export const MEDICATION_DISPENSE_ACTION_MENU_ITEM_SLOT = 'medication-dispense-action-menu-item-slot';

--- a/src/history/history-and-comments.component.tsx
+++ b/src/history/history-and-comments.component.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { OverflowMenu, OverflowMenuItem, SkeletonText, Tag, Tile } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
 import {
+  ExtensionSlot,
   formatDatetime,
   launchWorkspace2,
   parseDate,
@@ -106,6 +107,10 @@ const HistoryAndComments: React.FC<{
                   )}
                   patientUuid={patientUuid}
                   encounterUuid={encounterUuid}
+                />
+                <ExtensionSlot
+                  name="medication-dispense-action-slot"
+                  state={{ medicationDispense: dispense, patientUuid, encounterUuid }}
                 />
               </MedicationEvent>
             </div>

--- a/src/history/history-and-comments.component.tsx
+++ b/src/history/history-and-comments.component.tsx
@@ -9,6 +9,7 @@ import {
   type Session,
   showModal,
   showSnackbar,
+  useAssignedExtensions,
   useConfig,
   userHasAccess,
   useSession,
@@ -22,6 +23,7 @@ import { type MedicationDispense, MedicationDispenseStatus, type MedicationReque
 import {
   PRIVILEGE_DELETE_DISPENSE,
   PRIVILEGE_DELETE_DISPENSE_THIS_PROVIDER_ONLY,
+  MEDICATION_DISPENSE_ACTION_MENU_ITEM_SLOT,
   PRIVILEGE_EDIT_DISPENSE,
 } from '../constants';
 import {
@@ -107,10 +109,6 @@ const HistoryAndComments: React.FC<{
                   )}
                   patientUuid={patientUuid}
                   encounterUuid={encounterUuid}
-                />
-                <ExtensionSlot
-                  name="medication-dispense-action-slot"
-                  state={{ medicationDispense: dispense, patientUuid, encounterUuid }}
                 />
               </MedicationEvent>
             </div>
@@ -273,6 +271,7 @@ const MedicationDispenseActionMenu: React.FC<MedicationDispenseActionMenuProps> 
 
   const editable = userCanEdit(session);
   const deletable = userCanDelete(session, medicationDispense);
+  const slotExtensions = useAssignedExtensions(MEDICATION_DISPENSE_ACTION_MENU_ITEM_SLOT);
 
   const handleEdit = () => {
     const { workspaceName, props } = getDispenseWorkspaceConfig(medicationDispense, medicationRequestBundle) as {
@@ -297,33 +296,33 @@ const MedicationDispenseActionMenu: React.FC<MedicationDispenseActionMenuProps> 
     });
   };
 
-  if (!editable && !deletable) {
+  if (!editable && !deletable && slotExtensions.length === 0) {
     return null;
-  } else {
-    return (
-      <OverflowMenu
-        aria-label={t('medicationDispenseActionMenu', 'Medication Dispense Action Menu')}
-        className={styles.medicationEventActionMenu}
-        flipped>
-        {editable && (
-          <OverflowMenuItem
-            className={styles.menuitem}
-            itemText={t('editRecord', 'Edit record')}
-            onClick={handleEdit}
-          />
-        )}
-        {deletable && (
-          <OverflowMenuItem
-            className={styles.menuitem}
-            hasDivider
-            isDelete
-            itemText={t('delete', 'Delete')}
-            onClick={() => handleDeleteClick({ medicationDispense, medicationRequestBundle })}
-          />
-        )}
-      </OverflowMenu>
-    );
   }
+
+  return (
+    <OverflowMenu
+      aria-label={t('medicationDispenseActionMenu', 'Medication Dispense Action Menu')}
+      className={styles.medicationEventActionMenu}
+      flipped>
+      {editable && (
+        <OverflowMenuItem className={styles.menuitem} itemText={t('editRecord', 'Edit record')} onClick={handleEdit} />
+      )}
+      {deletable && (
+        <OverflowMenuItem
+          className={styles.menuitem}
+          hasDivider
+          isDelete
+          itemText={t('delete', 'Delete')}
+          onClick={() => handleDeleteClick({ medicationDispense, medicationRequestBundle })}
+        />
+      )}
+      <ExtensionSlot
+        name="medication-dispense-action-menu-item-slot"
+        state={{ medicationDispense, patientUuid, encounterUuid }}
+      />
+    </OverflowMenu>
+  );
 };
 
 const DispenseTag: React.FC<{ medicationDispense: MedicationDispense }> = ({ medicationDispense }) => {

--- a/src/history/history-and-comments.component.tsx
+++ b/src/history/history-and-comments.component.tsx
@@ -9,7 +9,6 @@ import {
   type Session,
   showModal,
   showSnackbar,
-  useAssignedExtensions,
   useConfig,
   userHasAccess,
   useSession,
@@ -23,7 +22,7 @@ import { type MedicationDispense, MedicationDispenseStatus, type MedicationReque
 import {
   PRIVILEGE_DELETE_DISPENSE,
   PRIVILEGE_DELETE_DISPENSE_THIS_PROVIDER_ONLY,
-  MEDICATION_DISPENSE_ACTION_MENU_ITEM_SLOT,
+  MEDICATION_DISPENSE_ACTION_SLOT,
   PRIVILEGE_EDIT_DISPENSE,
 } from '../constants';
 import {
@@ -101,15 +100,21 @@ const HistoryAndComments: React.FC<{
                 medicationEvent={dispense}
                 status={<DispenseTag medicationDispense={dispense} />}
                 isDispenseEvent>
-                <MedicationDispenseActionMenu
-                  medicationDispense={dispense}
-                  medicationRequestBundle={getMedicationRequestBundleContainingMedicationDispense(
-                    medicationRequestBundles,
-                    dispense,
-                  )}
-                  patientUuid={patientUuid}
-                  encounterUuid={encounterUuid}
-                />
+                <div className={styles.dispenseEventActions}>
+                  <ExtensionSlot
+                    name={MEDICATION_DISPENSE_ACTION_SLOT}
+                    state={{ medicationDispense: dispense, patientUuid, encounterUuid }}
+                  />
+                  <MedicationDispenseActionMenu
+                    medicationDispense={dispense}
+                    medicationRequestBundle={getMedicationRequestBundleContainingMedicationDispense(
+                      medicationRequestBundles,
+                      dispense,
+                    )}
+                    patientUuid={patientUuid}
+                    encounterUuid={encounterUuid}
+                  />
+                </div>
               </MedicationEvent>
             </div>
           ))}
@@ -271,7 +276,6 @@ const MedicationDispenseActionMenu: React.FC<MedicationDispenseActionMenuProps> 
 
   const editable = userCanEdit(session);
   const deletable = userCanDelete(session, medicationDispense);
-  const slotExtensions = useAssignedExtensions(MEDICATION_DISPENSE_ACTION_MENU_ITEM_SLOT);
   const [menuOpen, setMenuOpen] = useState(false);
 
   const handleEdit = () => {
@@ -297,7 +301,7 @@ const MedicationDispenseActionMenu: React.FC<MedicationDispenseActionMenuProps> 
     });
   };
 
-  if (!editable && !deletable && slotExtensions.length === 0) {
+  if (!editable && !deletable) {
     return null;
   }
 
@@ -321,10 +325,6 @@ const MedicationDispenseActionMenu: React.FC<MedicationDispenseActionMenuProps> 
           onClick={() => handleDeleteClick({ medicationDispense, medicationRequestBundle })}
         />
       )}
-      <ExtensionSlot
-        name={MEDICATION_DISPENSE_ACTION_MENU_ITEM_SLOT}
-        state={{ medicationDispense, patientUuid, encounterUuid, closeMenu: () => setMenuOpen(false) }}
-      />
     </OverflowMenu>
   );
 };

--- a/src/history/history-and-comments.component.tsx
+++ b/src/history/history-and-comments.component.tsx
@@ -302,27 +302,31 @@ const MedicationDispenseActionMenu: React.FC<MedicationDispenseActionMenuProps> 
 
   if (!editable && !deletable) {
     return null;
+  } else {
+    return (
+      <OverflowMenu
+        aria-label={t('medicationDispenseActionMenu', 'Medication Dispense Action Menu')}
+        className={styles.medicationEventActionMenu}
+        flipped>
+        {editable && (
+          <OverflowMenuItem
+            className={styles.menuitem}
+            itemText={t('editRecord', 'Edit record')}
+            onClick={handleEdit}
+          />
+        )}
+        {deletable && (
+          <OverflowMenuItem
+            className={styles.menuitem}
+            hasDivider
+            isDelete
+            itemText={t('delete', 'Delete')}
+            onClick={() => handleDeleteClick({ medicationDispense, medicationRequestBundle })}
+          />
+        )}
+      </OverflowMenu>
+    );
   }
-
-  return (
-    <OverflowMenu
-      aria-label={t('medicationDispenseActionMenu', 'Medication Dispense Action Menu')}
-      className={styles.medicationEventActionMenu}
-      flipped>
-      {editable && (
-        <OverflowMenuItem className={styles.menuitem} itemText={t('editRecord', 'Edit record')} onClick={handleEdit} />
-      )}
-      {deletable && (
-        <OverflowMenuItem
-          className={styles.menuitem}
-          hasDivider
-          isDelete
-          itemText={t('delete', 'Delete')}
-          onClick={() => handleDeleteClick({ medicationDispense, medicationRequestBundle })}
-        />
-      )}
-    </OverflowMenu>
-  );
 };
 
 const DispenseTag: React.FC<{ medicationDispense: MedicationDispense }> = ({ medicationDispense }) => {

--- a/src/history/history-and-comments.component.tsx
+++ b/src/history/history-and-comments.component.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { OverflowMenu, OverflowMenuItem, SkeletonText, Tag, Tile } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -276,7 +276,6 @@ const MedicationDispenseActionMenu: React.FC<MedicationDispenseActionMenuProps> 
 
   const editable = userCanEdit(session);
   const deletable = userCanDelete(session, medicationDispense);
-  const [menuOpen, setMenuOpen] = useState(false);
 
   const handleEdit = () => {
     const { workspaceName, props } = getDispenseWorkspaceConfig(medicationDispense, medicationRequestBundle) as {
@@ -309,10 +308,7 @@ const MedicationDispenseActionMenu: React.FC<MedicationDispenseActionMenuProps> 
     <OverflowMenu
       aria-label={t('medicationDispenseActionMenu', 'Medication Dispense Action Menu')}
       className={styles.medicationEventActionMenu}
-      flipped
-      open={menuOpen}
-      onClick={() => setMenuOpen((prev) => !prev)}
-      onClose={() => setMenuOpen(false)}>
+      flipped>
       {editable && (
         <OverflowMenuItem className={styles.menuitem} itemText={t('editRecord', 'Edit record')} onClick={handleEdit} />
       )}

--- a/src/history/history-and-comments.component.tsx
+++ b/src/history/history-and-comments.component.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { OverflowMenu, OverflowMenuItem, SkeletonText, Tag, Tile } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -272,6 +272,7 @@ const MedicationDispenseActionMenu: React.FC<MedicationDispenseActionMenuProps> 
   const editable = userCanEdit(session);
   const deletable = userCanDelete(session, medicationDispense);
   const slotExtensions = useAssignedExtensions(MEDICATION_DISPENSE_ACTION_MENU_ITEM_SLOT);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   const handleEdit = () => {
     const { workspaceName, props } = getDispenseWorkspaceConfig(medicationDispense, medicationRequestBundle) as {
@@ -304,7 +305,10 @@ const MedicationDispenseActionMenu: React.FC<MedicationDispenseActionMenuProps> 
     <OverflowMenu
       aria-label={t('medicationDispenseActionMenu', 'Medication Dispense Action Menu')}
       className={styles.medicationEventActionMenu}
-      flipped>
+      flipped
+      open={menuOpen}
+      onClick={() => setMenuOpen((prev) => !prev)}
+      onClose={() => setMenuOpen(false)}>
       {editable && (
         <OverflowMenuItem className={styles.menuitem} itemText={t('editRecord', 'Edit record')} onClick={handleEdit} />
       )}
@@ -318,8 +322,8 @@ const MedicationDispenseActionMenu: React.FC<MedicationDispenseActionMenuProps> 
         />
       )}
       <ExtensionSlot
-        name="medication-dispense-action-menu-item-slot"
-        state={{ medicationDispense, patientUuid, encounterUuid }}
+        name={MEDICATION_DISPENSE_ACTION_MENU_ITEM_SLOT}
+        state={{ medicationDispense, patientUuid, encounterUuid, closeMenu: () => setMenuOpen(false) }}
       />
     </OverflowMenu>
   );

--- a/src/history/history-and-comments.scss
+++ b/src/history/history-and-comments.scss
@@ -37,6 +37,10 @@
   max-width: none;
 }
 
+:global([data-extension-slot-name='medication-dispense-action-menu-item-slot']) {
+  width: 100%;
+}
+
 .historyHeader {
   padding-top: layout.$spacing-03;
   padding-bottom: layout.$spacing-03;

--- a/src/history/history-and-comments.scss
+++ b/src/history/history-and-comments.scss
@@ -37,8 +37,10 @@
   max-width: none;
 }
 
-:global([data-extension-slot-name='medication-dispense-action-menu-item-slot']) {
-  width: 100%;
+.dispenseEventActions {
+  display: flex;
+  align-items: flex-start;
+  gap: layout.$spacing-03;
 }
 
 .historyHeader {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
Adds ability to add additional menu items to the medication dispense overflow menu

## Screenshots
<img width="3706" height="1148" alt="image" src="https://github.com/user-attachments/assets/694f9d49-8558-43c7-87e0-d1e22b857cb5" />

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-5690

## Other
<!-- Anything not covered above -->
