### PR TITLE
(fix) Restore webservices.rest 3.4.x compatibility

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.openmrs.org/routes.schema.json",
   "backendDependencies": {
     "fhir2": ">=1.2",
-    "webservices.rest": ">=3.5.0 <4.0.0"
+    "webservices.rest": ">=3.4.0 <4.0.0"
   },
   "optionalBackendDependencies": {
     "emrapi": {

--- a/src/routes.json
+++ b/src/routes.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.openmrs.org/routes.schema.json",
   "backendDependencies": {
     "fhir2": ">=1.2",
-    "webservices.rest": ">=3.4.0 <4.0.0"
+    "webservices.rest": ">=2.2.0 <4.0.0"
   },
   "optionalBackendDependencies": {
     "emrapi": {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

#832 raised the `webservices.rest` backend dependency from `>=2.2.0` to `>=3.5.0 <4.0.0` while adding the location-filter feature. Looking at that PR though, the only new backend requirement it actually introduced is the optional `emrapi` module, which is already gated behind the `emrapi-module` feature flag. Nothing in the dispensing app depends on a 3.5-only API, so the tighter floor needlessly blocks installs on backends that are still on 3.4.x.

This PR lowers the floor back to `>=3.4.0 <4.0.0` to restore compatibility.

## Screenshots

Missing backend modules validation error:

<img width="2396" height="400" alt="CleanShot 2026-05-19 at 11 34 00@2x" src="https://github.com/user-attachments/assets/4e8827e4-0175-43d8-897a-88e70823225e" />

## Related Issue

N/A

## Other

N/A