### PR TITLE
(feat) O3-5650: Add ability to limit prescriptions to user's visit lo…

### DIFF
--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -96,12 +96,12 @@ export const configSchema = {
           "Name of the location attribute whose value identifies the associated pharmacy location. The location whose attribute value matches the user's login location will be pre-selected in the filter dropdown. This attribute has no effect on which locations appear as options.",
         _default: 'Associated Pharmacy Location',
       },
-      restrictToVisitLocationDescendants: {
-        _type: Type.Boolean,
-        _description:
-          "If true, further restricts the dropdown options to locations that are descendants of the current login location's nearest ancestor tagged as a visit location. Requires the EMR API module to be installed.",
-        _default: false,
-      },
+    },
+    restrictToVisitLocationDescendants: {
+      _type: Type.Boolean,
+      _description:
+        "If true, limits prescriptions shown to locations that are descendants of the current login location's nearest ancestor tagged as a visit location. Requires the EMR API module to be installed.",
+      _default: false,
     },
   },
   refreshInterval: {
@@ -204,8 +204,8 @@ export interface PharmacyConfig {
       enabled: boolean;
       tag: string;
       associatedPharmacyLocationAttribute: string;
-      restrictToVisitLocationDescendants: boolean;
     };
+    restrictToVisitLocationDescendants: boolean;
   };
   valueSets: {
     reasonForPause: {

--- a/src/location/location.resource.test.tsx
+++ b/src/location/location.resource.test.tsx
@@ -36,8 +36,8 @@ const pharmacyConfig: PharmacyConfig = {
       enabled: false,
       tag: 'Login Location',
       associatedPharmacyLocationAttribute: 'Associated Pharmacy Location',
-      restrictToVisitLocationDescendants: false,
     },
+    restrictToVisitLocationDescendants: false,
   },
   refreshInterval: 10000,
   medicationRequestExpirationPeriodInDays: 0,
@@ -122,10 +122,7 @@ describe('useLocations', () => {
       ...pharmacyConfig,
       locationBehavior: {
         ...pharmacyConfig.locationBehavior,
-        locationFilter: {
-          ...pharmacyConfig.locationBehavior.locationFilter,
-          restrictToVisitLocationDescendants: true,
-        },
+        restrictToVisitLocationDescendants: true,
       },
     };
 

--- a/src/location/location.resource.tsx
+++ b/src/location/location.resource.tsx
@@ -25,7 +25,7 @@ export class MissingOptionalBackendDependencyError extends Error {
  * Location options are further filtered with the tag specified in the configuration.
  */
 export function useLocations(config: PharmacyConfig) {
-  const { restrictToVisitLocationDescendants } = config.locationBehavior.locationFilter;
+  const { restrictToVisitLocationDescendants } = config.locationBehavior;
   const byTag = useLocationsByTag(config, !restrictToVisitLocationDescendants);
   const byVisit = useVisitLocationDescendants(config, restrictToVisitLocationDescendants);
   return restrictToVisitLocationDescendants ? byVisit : byTag;

--- a/src/prescriptions/prescription-tab-lists.component.tsx
+++ b/src/prescriptions/prescription-tab-lists.component.tsx
@@ -13,7 +13,7 @@ const PrescriptionTabLists: React.FC = () => {
   const { t } = useTranslation();
   const config = useConfig<PharmacyConfig>();
   const session = useSession();
-  const { error: locationsError } = useLocations(config);
+  const { locations, isLoading: isLocationsLoading, error: locationsError } = useLocations(config);
 
   useEffect(() => {
     if (locationsError instanceof MissingOptionalBackendDependencyError) {
@@ -67,12 +67,24 @@ const PrescriptionTabLists: React.FC = () => {
           </TabList>
           <TabPanels>
             <PatientSearchTabPanel />
-            <PrescriptionTabPanel isTabActive={selectedTab === 1} status={'ACTIVE'} />
-            <PrescriptionTabPanel isTabActive={selectedTab === 2} status={''} />
+            <PrescriptionTabPanel
+              isTabActive={selectedTab === 1}
+              status={'ACTIVE'}
+              locations={locations}
+              isLocationsLoading={isLocationsLoading}
+            />
+            <PrescriptionTabPanel
+              isTabActive={selectedTab === 2}
+              status={''}
+              locations={locations}
+              isLocationsLoading={isLocationsLoading}
+            />
             {customTabs.map((tab, index) => (
               <PrescriptionTabPanel
                 isTabActive={selectedTab === index + 3}
                 customPrescriptionsTableEndpoint={tab.customPrescriptionsTableEndpoint}
+                locations={locations}
+                isLocationsLoading={isLocationsLoading}
               />
             ))}
           </TabPanels>

--- a/src/prescriptions/prescription-tab-panel.component.test.tsx
+++ b/src/prescriptions/prescription-tab-panel.component.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { useConfig, useSession } from '@openmrs/esm-framework';
+import { usePrescriptionsTable } from '../medication-request/medication-request.resource';
+import PrescriptionTabPanel from './prescription-tab-panel.component';
+import { type SimpleLocation } from '../types';
+
+vi.mock('../medication-request/medication-request.resource');
+
+const mockUseConfig = vi.mocked(useConfig);
+const mockUseSession = vi.mocked(useSession);
+const mockUsePrescriptionsTable = vi.mocked(usePrescriptionsTable);
+
+const descendantLocations: SimpleLocation[] = [
+  { id: 'loc-mch', name: 'KGH MCH', associatedPharmacyLocation: null },
+  { id: 'loc-triage', name: 'KGH Triage', associatedPharmacyLocation: null },
+];
+
+beforeEach(() => {
+  mockUsePrescriptionsTable.mockReturnValue({
+    prescriptionsTableRows: [],
+    error: undefined,
+    isLoading: false,
+    totalOrders: 0,
+  });
+  mockUseSession.mockReturnValue({ sessionLocation: { uuid: 'session-uuid' } } as any);
+});
+
+describe('PrescriptionTabPanel', () => {
+  it('restricts the data fetch to visit location descendants when restrictToVisitLocationDescendants is true and no filter location is selected', () => {
+    mockUseConfig.mockReturnValue({
+      locationBehavior: {
+        locationColumn: { enabled: false },
+        locationFilter: { enabled: false },
+        restrictToVisitLocationDescendants: true,
+      },
+      medicationRequestExpirationPeriodInDays: 90,
+      refreshInterval: 10000,
+    });
+
+    render(<PrescriptionTabPanel isTabActive={true} locations={descendantLocations} isLocationsLoading={false} />);
+
+    const [, , , , , , locationsPassedToFetch] = mockUsePrescriptionsTable.mock.lastCall;
+    expect(locationsPassedToFetch).toEqual(descendantLocations);
+  });
+
+  it('fetches without a location restriction when restrictToVisitLocationDescendants is false and no filter is selected', () => {
+    mockUseConfig.mockReturnValue({
+      locationBehavior: {
+        locationColumn: { enabled: false },
+        locationFilter: { enabled: false },
+        restrictToVisitLocationDescendants: false,
+      },
+      medicationRequestExpirationPeriodInDays: 90,
+      refreshInterval: 10000,
+    });
+
+    render(<PrescriptionTabPanel isTabActive={true} locations={descendantLocations} isLocationsLoading={false} />);
+
+    const [, , , , , , locationsPassedToFetch] = mockUsePrescriptionsTable.mock.lastCall;
+    expect(locationsPassedToFetch).toEqual([]);
+  });
+});

--- a/src/prescriptions/prescription-tab-panel.component.tsx
+++ b/src/prescriptions/prescription-tab-panel.component.tsx
@@ -5,32 +5,34 @@ import { useConfig, useDebounce, useSession } from '@openmrs/esm-framework';
 import { type PharmacyConfig } from '../config-schema';
 import PrescriptionsTable from './prescriptions-table.component';
 import styles from './prescriptions.scss';
-import { useLocations } from '../location/location.resource';
 import { type SimpleLocation } from '../types';
 
 interface PrescriptionTabPanelProps {
   isTabActive: boolean;
   status?: string;
   customPrescriptionsTableEndpoint?: string;
+  locations: SimpleLocation[];
+  isLocationsLoading: boolean;
 }
 
 const PrescriptionTabPanel: React.FC<PrescriptionTabPanelProps> = ({
   status,
   isTabActive,
   customPrescriptionsTableEndpoint,
+  locations,
+  isLocationsLoading,
 }) => {
   const { t } = useTranslation();
   const config = useConfig<PharmacyConfig>();
   const isInitialized = useRef(false);
   const { sessionLocation } = useSession();
-  const { locations, isLoading: isFilterLocationsLoading } = useLocations(config);
   const [searchTerm, setSearchTerm] = useState('');
   const debouncedSearchTerm = useDebounce(searchTerm, 500);
   const [filterLocations, setFilterLocations] = useState<SimpleLocation[]>([]);
 
   // set any initially selected locations
   useEffect(() => {
-    if (!isInitialized.current && !isFilterLocationsLoading && sessionLocation?.uuid) {
+    if (!isInitialized.current && !isLocationsLoading && sessionLocation?.uuid) {
       setFilterLocations(
         locations?.filter((l) => {
           return sessionLocation?.uuid === l.associatedPharmacyLocation;
@@ -38,13 +40,13 @@ const PrescriptionTabPanel: React.FC<PrescriptionTabPanelProps> = ({
       );
       isInitialized.current = true; // we only want to run when the component is first mounted so we don't override user changes
     }
-  }, [isFilterLocationsLoading, sessionLocation, locations]);
+  }, [isLocationsLoading, sessionLocation, locations]);
 
   return (
     <TabPanel>
       <div className={styles.searchContainer}>
         {config.locationBehavior?.locationFilter?.enabled &&
-          !isFilterLocationsLoading &&
+          !isLocationsLoading &&
           isInitialized.current &&
           locations?.length > 1 && (
             <MultiSelect
@@ -78,7 +80,11 @@ const PrescriptionTabPanel: React.FC<PrescriptionTabPanelProps> = ({
         status={status}
         customPrescriptionsTableEndpoint={customPrescriptionsTableEndpoint}
         debouncedSearchTerm={debouncedSearchTerm}
-        locations={filterLocations}
+        locations={
+          config.locationBehavior.restrictToVisitLocationDescendants && filterLocations.length === 0
+            ? locations
+            : filterLocations
+        }
       />
     </TabPanel>
   );

--- a/src/routes.json
+++ b/src/routes.json
@@ -10,7 +10,7 @@
       "feature": {
         "flagName": "emrapi-module",
         "label": "EMR API Module",
-        "description": "Required if the locationBehavior.locationFilter.restrictToVisitLocationDescendants config is set to true."
+        "description": "Required if the locationBehavior.restrictToVisitLocationDescendants config is set to true."
       }
     }
   },


### PR DESCRIPTION
…cation

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Previous commit e03985d missed a requirement that when `restrictToVisitLocationDescendants` is configured to true, we should not only restrict the location filter options to descendants of the user session's visit location, but also further restrict prescription rows to only those locations, even if the user did not select anything in the location filter.  This PR fixes that.

Also lifted the `restrictToVisitLocationDescendants` config from `locationBehavior.locationFilter` to `locationBehavior` as it affects more than just the filter.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://issues.openmrs.org/browse/O3-5650

## Other
<!-- Anything not covered above -->
