### PR TITLE
(fix) O3-5650: Subject results in the search tab to location filterin…

### DIFF
--- a/src/prescriptions/patient-search-tab-panel.component.tsx
+++ b/src/prescriptions/patient-search-tab-panel.component.tsx
@@ -4,8 +4,13 @@ import { useTranslation } from 'react-i18next';
 import { PatientSearchPictogram } from '@openmrs/esm-framework';
 import PrescriptionsTable from './prescriptions-table.component';
 import styles from './patient-search-tab-panel.scss';
+import { type SimpleLocation } from '../types';
 
-const PatientSearchTabPanel: React.FC = () => {
+interface PatientSearchTabPanelProps {
+  locations: Array<SimpleLocation>;
+}
+
+const PatientSearchTabPanel: React.FC<PatientSearchTabPanelProps> = ({ locations }) => {
   const { t } = useTranslation();
   const [searchTerm, setSearchTerm] = useState('');
   const [submittedSearchTerm, setSubmittedSearchTerm] = useState('');
@@ -39,7 +44,7 @@ const PatientSearchTabPanel: React.FC = () => {
             loadData={true}
             status={'ACTIVE'}
             debouncedSearchTerm={submittedSearchTerm}
-            locations={[]}
+            locations={locations}
           />
         ) : (
           <div className={styles.searchForPatientPlaceholder}>

--- a/src/prescriptions/prescription-tab-lists.component.tsx
+++ b/src/prescriptions/prescription-tab-lists.component.tsx
@@ -66,7 +66,7 @@ const PrescriptionTabLists: React.FC = () => {
             ))}
           </TabList>
           <TabPanels>
-            <PatientSearchTabPanel />
+            <PatientSearchTabPanel locations={locations} />
             <PrescriptionTabPanel
               isTabActive={selectedTab === 1}
               status={'ACTIVE'}


### PR DESCRIPTION
…g config

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
12a722e added a new config: `locationBehavior.restrictToVisitLocationDescendants`. When set to true, it should limit the dispensing rows we see to only those from locations under the session's visit location. This restriction was implemented for the "Active Prescription" and "All Prescription" tabs, but not the "Search" tab. This PR fixes that.

## Screenshots
<!-- Required if you are making UI changes. -->
The search tab now only shows prescriptions from sub-locations of the session's visit location.

<img width="3151" height="1678" alt="image" src="https://github.com/user-attachments/assets/0030f5dd-af32-4304-8f74-2ee6ac154e9e" />


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
