### PR TITLE
(fix) O3-5734: Allow recording allergies from the fill prescription order basket

### DIFF
--- a/src/fill-prescription/fill-prescription-button.component.tsx
+++ b/src/fill-prescription/fill-prescription-button.component.tsx
@@ -47,6 +47,7 @@ const FillPrescriptionButton: React.FC<{}> = () => {
                   patient: patient,
                   visitContext: activeVisit,
                   drugOrderWorkspaceName: 'dispensing-order-basket-add-drug-order-workspace',
+                  allergyFormWorkspaceName: 'dispensing-order-basket-add-allergy-workspace',
                   visibleOrderPanels: [drugOrderTypeUUID],
                   onOrderBasketSubmitted: (encounterUuid: string, _: Array<Order>) => {
                     showModal('on-prescription-filled-modal', {

--- a/src/routes.json
+++ b/src/routes.json
@@ -111,6 +111,11 @@
       "name": "dispensing-order-basket-add-drug-order-workspace",
       "component": "@openmrs/esm-patient-medications-app#exportedAddDrugOrderWorkspace",
       "window": "fill-prescription-window"
+    },
+    {
+      "name": "dispensing-order-basket-add-allergy-workspace",
+      "component": "@openmrs/esm-patient-allergies-app#exportedAllergyFormWorkspace",
+      "window": "fill-prescription-window"
     }
   ],
   "workspaceWindows2": [


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

The "Add allergy" (+) control in the order basket's drug search falls back to launching the patient chart's allergy form workspace when the host doesn't provide a launcher. The fill prescription workflow renders the order basket outside the patient chart, so that fallback opened the `patient-chart` workspace group with null group props and crashed every action button registered to it with `Cannot read properties of null (reading 'patientUuid')`.

This registers the exported allergy form workspace (added in openmrs/openmrs-esm-patient-chart#3353) into the `fill-prescription-window` and passes its name as `allergyFormWorkspaceName` in the order basket window props, so the form opens as a child of the dispensing app's own workspace window. This is the same wiring the ward app added in openmrs/openmrs-esm-patient-management#2561.

Note: this requires the patient chart release that ships `exportedAllergyFormWorkspace` (v12.2.0 or higher).

## Screenshots

https://github.com/user-attachments/assets/c25747d4-3f81-484a-87e2-7c4c9c1c396a

## Related Issue

https://openmrs.atlassian.net/browse/O3-5734

## Other
