### PR TITLE
(fix) Refresh prescriptions table in place after dispensing

### DIFF
--- a/src/fill-prescription/on-prescription-filled.modal.tsx
+++ b/src/fill-prescription/on-prescription-filled.modal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useSWRConfig } from 'swr';
 import { Button, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
 import { Trans, useTranslation } from 'react-i18next';
 import { getPatientName, showSnackbar, useConfig, useSession } from '@openmrs/esm-framework';
@@ -48,6 +49,7 @@ const OnPrescriptionFilledModal: React.FC<OnPrescriptionFilledModalProps> = ({ p
   const providers = useProviders(dispenserProviderRoles);
   const { medicationRequestBundles, isLoading: isLoadingPrescriptionDetails } = usePrescriptionDetails(encounterUuid);
   const { t } = useTranslation();
+  const { mutate } = useSWRConfig();
   const [isSubmitting, setIsSubmitting] = React.useState(false);
 
   const onConfirm = async () => {
@@ -100,7 +102,7 @@ const OnPrescriptionFilledModal: React.FC<OnPrescriptionFilledModalProps> = ({ p
 
       close();
     } finally {
-      revalidate(encounterUuid);
+      revalidate(mutate, encounterUuid);
       setIsSubmitting(false);
     }
   };

--- a/src/forms/close-dispense-form.workspace.tsx
+++ b/src/forms/close-dispense-form.workspace.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { useSWRConfig } from 'swr';
 import { useTranslation } from 'react-i18next';
 import { Button, ComboBox, Form, InlineLoading } from '@carbon/react';
 import {
@@ -31,6 +32,7 @@ const CloseDispenseForm: React.FC<Workspace2DefinitionProps<CloseDispenseFormPro
   closeWorkspace,
 }) => {
   const { t } = useTranslation();
+  const { mutate } = useSWRConfig();
   const config = useConfig<PharmacyConfig>();
   const { patient, isLoading } = usePatient(patientUuid);
 
@@ -84,7 +86,7 @@ const CloseDispenseForm: React.FC<Workspace2DefinitionProps<CloseDispenseFormPro
         })
         .then((response) => {
           if (response.ok) {
-            revalidate(encounterUuid);
+            revalidate(mutate, encounterUuid);
             showSnackbar({
               kind: 'success',
               title: t(

--- a/src/forms/dispense-form.workspace.tsx
+++ b/src/forms/dispense-form.workspace.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSWRConfig } from 'swr';
 import { useTranslation } from 'react-i18next';
 import { Button, Checkbox, Form, FormLabel, InlineLoading } from '@carbon/react';
 import {
@@ -62,6 +63,7 @@ const DispenseForm: React.FC<Workspace2DefinitionProps<DispenseFormProps, {}, {}
   closeWorkspace,
 }) => {
   const { t } = useTranslation();
+  const { mutate } = useSWRConfig();
   const { patient, isLoading } = usePatient(patientUuid);
   const config = useConfig<PharmacyConfig>();
 
@@ -226,7 +228,7 @@ const DispenseForm: React.FC<Workspace2DefinitionProps<DispenseFormProps, {}, {}
             });
           }
           if (status === 201 || status === 200) {
-            revalidate(encounterUuid);
+            revalidate(mutate, encounterUuid);
             showSnackbar({
               kind: 'success',
               subtitle: t('medicationListUpdated', 'Medication dispense list has been updated.'),

--- a/src/forms/pause-dispense-form.workspace.tsx
+++ b/src/forms/pause-dispense-form.workspace.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { useSWRConfig } from 'swr';
 import { useTranslation } from 'react-i18next';
 import { Button, ComboBox, Form, InlineLoading } from '@carbon/react';
 import {
@@ -31,6 +32,7 @@ const PauseDispenseForm: React.FC<Workspace2DefinitionProps<PauseDispenseFormPro
   closeWorkspace,
 }) => {
   const { t } = useTranslation();
+  const { mutate } = useSWRConfig();
   const config = useConfig<PharmacyConfig>();
   const { patient, isLoading } = usePatient(patientUuid);
 
@@ -84,7 +86,7 @@ const PauseDispenseForm: React.FC<Workspace2DefinitionProps<PauseDispenseFormPro
         })
         .then((response) => {
           if (response.ok) {
-            revalidate(encounterUuid);
+            revalidate(mutate, encounterUuid);
             showSnackbar({
               kind: 'success',
               title: t(

--- a/src/history/history-and-comments.component.tsx
+++ b/src/history/history-and-comments.component.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { useSWRConfig } from 'swr';
 import { OverflowMenu, OverflowMenuItem, SkeletonText, Tag, Tile } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -146,6 +147,7 @@ const MedicationDispenseActionMenu: React.FC<MedicationDispenseActionMenuProps> 
   encounterUuid,
 }) => {
   const { t } = useTranslation();
+  const { mutate } = useSWRConfig();
   const session = useSession();
   const config = useConfig<PharmacyConfig>();
   const userCanEdit = (session: Session): boolean =>
@@ -253,7 +255,7 @@ const MedicationDispenseActionMenu: React.FC<MedicationDispenseActionMenuProps> 
             newFulfillerStatus,
           )
             .then(() => {
-              revalidate(encounterUuid);
+              revalidate(mutate, encounterUuid);
             })
             .catch(() => {
               showSnackbar({
@@ -263,7 +265,7 @@ const MedicationDispenseActionMenu: React.FC<MedicationDispenseActionMenuProps> 
               });
             });
         }
-        revalidate(encounterUuid);
+        revalidate(mutate, encounterUuid);
       })
       .catch(() => {
         showSnackbar({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs';
 import template from 'lodash/template';
-import { mutate } from 'swr';
+import { type ScopedMutator } from 'swr/_internal';
 import {
   type Coding,
   type DispensingStore,
@@ -580,10 +580,16 @@ export function isMostRecentMedicationDispense(
 
 /**
  * Revalidated (reloads) both the prescription associated with the encounter uuid,
- * and the entire prescription table
+ * and the entire prescription table.
+ *
+ * The `mutate` must be the one obtained from `useSWRConfig()` in the calling component, not the
+ * global `mutate` imported from `swr`. OpenMRS wraps every microfrontend in an `<SWRConfig>` with a
+ * custom cache provider, so the global `mutate` (bound to SWR's default cache) does not see the
+ * app's cached entries and would silently no-op.
+ * @param mutate the cache-bound mutator from `useSWRConfig()`
  * @param encounterUuid
  */
-export async function revalidate(encounterUuid: string) {
+export async function revalidate(mutate: ScopedMutator, encounterUuid: string) {
   await mutate(
     (key) =>
       typeof key === 'string' &&

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs';
 import template from 'lodash/template';
-import { type ScopedMutator } from 'swr/_internal';
+import { type useSWRConfig } from 'swr';
 import {
   type Coding,
   type DispensingStore,
@@ -24,6 +24,8 @@ import {
   PRESCRIPTION_DETAILS_ENDPOINT,
   PRESCRIPTIONS_TABLE_ENDPOINT,
 } from './constants';
+
+type ScopedMutator = ReturnType<typeof useSWRConfig>['mutate'];
 
 const unitsDontMatchErrorMessage =
   "Misconfiguration, please contact your System Administrator:  Can't calculate quantity dispensed if units don't match. Likely issue: allowModifyingPrescription and restrictTotalQuantityDispensed configuration parameters both set to true. " +


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

When dispensing (or pausing/closing/deleting) a prescription, the prescriptions table did not update in place — the status and last-dispenser only changed after switching tabs or manually refreshing.

The root cause is a SWR cache mismatch. `revalidate()` in `src/utils.ts` used the **global `mutate` imported from `swr`**, which is permanently bound to SWR's *default* cache. OpenMRS wraps every microfrontend in an `<SWRConfig>` with a **custom cache provider** (`@openmrs/esm-react-utils` → `provider: () => swrCache`), so all `useSWR` data — including the prescriptions table — lives in that provider's cache. The global `mutate`'s key filter therefore matched nothing and the table entry was never revalidated.

Switching tabs appeared to "fix" it only because `loadData={isTabActive}` flips the SWR key (`null` ↔ URL), which forces a fresh fetch independently of `mutate`.

### Fix

Pass the cache-bound `mutate` from `useSWRConfig()` into `revalidate()` so it targets the active provider's cache:

- `revalidate(encounterUuid)` → `revalidate(mutate, encounterUuid)`
- Updated all callers: dispense / close / pause forms, the on-prescription-filled modal, and the delete handler in `history-and-comments`.

## Screenshots

Before - 

https://github.com/user-attachments/assets/9b5c9a2a-9948-49ca-9f21-e03d5dffb85f


After - 

https://github.com/user-attachments/assets/51990da6-9a9b-4968-a27b-6a9e8684b6a1



## Related Issue

<!-- No Jira ticket. -->

## Other
