### PR TITLE
(feat) O3-5907: Show medication side effects on prescription details

### DIFF
--- a/src/components/medication-event.component.tsx
+++ b/src/components/medication-event.component.tsx
@@ -21,8 +21,10 @@ const MedicationEvent: React.FC<{
   medicationEvent: MedicationRequest | MedicationDispense;
   status?: ReactNode;
   children?: ReactNode;
+  footer?: ReactNode;
+  alignContentStart?: boolean;
   isDispenseEvent?: boolean;
-}> = ({ medicationEvent, status = null, children, isDispenseEvent }) => {
+}> = ({ medicationEvent, status = null, children, footer = null, alignContentStart = false, isDispenseEvent }) => {
   const { t } = useTranslation();
   const dosageInstruction = getDosageInstruction(medicationEvent.dosageInstruction);
   const isFreeTextDosage = calculateIsFreeTextDosage(dosageInstruction);
@@ -37,58 +39,61 @@ const MedicationEvent: React.FC<{
         [styles.dispenseEvent]: isDispenseEvent,
         [styles.isTablet]: isTablet,
       })}>
-      <div>
-        <p className={styles.medicationName}>
-          {status}
-          {status && ' '}
-          <strong>{getMedicationDisplay(getMedicationReferenceOrCodeableConcept(medicationEvent))}</strong>
-        </p>
-
-        {!isFreeTextDosage && (
-          <p className={styles.bodyLong01}>
-            <span className={styles.label01}>{t('dose', 'Dose').toUpperCase()}</span>{' '}
-            <span className={styles.dosage}>
-              {dosageInstruction?.doseAndRate &&
-                dosageInstruction.doseAndRate.map((doseAndRate, index) => {
-                  return (
-                    <span key={index}>
-                      {doseAndRate?.doseQuantity?.value} {doseAndRate?.doseQuantity?.unit}
-                    </span>
-                  );
-                })}
-            </span>
-            {dosageInstruction?.route?.text && <> &mdash; {dosageInstruction.route.text}</>}
-            {dosageInstruction?.timing?.code?.text && <> &mdash; {dosageInstruction.timing.code.text}</>}
-            {dosageInstruction?.timing?.repeat?.duration && (
-              <>
-                {' '}
-                for {dosageInstruction.timing.repeat.duration} {dosageInstruction.timing.repeat.durationUnit}
-              </>
-            )}
+      <div className={classNames(styles.content, { [styles.contentStart]: alignContentStart })}>
+        <div>
+          <p className={styles.medicationName}>
+            {status}
+            {status && ' '}
+            <strong>{getMedicationDisplay(getMedicationReferenceOrCodeableConcept(medicationEvent))}</strong>
           </p>
-        )}
 
-        {quantity && (
-          <p className={styles.bodyLong01}>
-            <span className={styles.label01}>{t('quantity', 'Quantity').toUpperCase()}</span>{' '}
-            <span className={styles.quantity}>
-              {quantity.value} {quantity.unit}
-            </span>
-          </p>
-        )}
+          {!isFreeTextDosage && (
+            <p className={styles.bodyLong01}>
+              <span className={styles.label01}>{t('dose', 'Dose').toUpperCase()}</span>{' '}
+              <span className={styles.dosage}>
+                {dosageInstruction?.doseAndRate &&
+                  dosageInstruction.doseAndRate.map((doseAndRate, index) => {
+                    return (
+                      <span key={index}>
+                        {doseAndRate?.doseQuantity?.value} {doseAndRate?.doseQuantity?.unit}
+                      </span>
+                    );
+                  })}
+              </span>
+              {dosageInstruction?.route?.text && <> &mdash; {dosageInstruction.route.text}</>}
+              {dosageInstruction?.timing?.code?.text && <> &mdash; {dosageInstruction.timing.code.text}</>}
+              {dosageInstruction?.timing?.repeat?.duration && (
+                <>
+                  {' '}
+                  for {dosageInstruction.timing.repeat.duration} {dosageInstruction.timing.repeat.durationUnit}
+                </>
+              )}
+            </p>
+          )}
 
-        {(refillsAllowed || refillsAllowed === 0) && (
-          <p className={styles.bodyLong01}>
-            <span className={styles.label01}>{t('refills', 'Refills').toUpperCase()}</span>{' '}
-            <span className={styles.refills}>{refillsAllowed}</span>
-          </p>
-        )}
-        {dosageInstruction?.text && <p className={styles.bodyLong01}>{dosageInstruction.text}</p>}
-        {dosageInstruction?.additionalInstruction?.length > 0 && (
-          <p className={styles.bodyLong01}>{dosageInstruction?.additionalInstruction[0].text}</p>
-        )}
+          {quantity && (
+            <p className={styles.bodyLong01}>
+              <span className={styles.label01}>{t('quantity', 'Quantity').toUpperCase()}</span>{' '}
+              <span className={styles.quantity}>
+                {quantity.value} {quantity.unit}
+              </span>
+            </p>
+          )}
+
+          {(refillsAllowed || refillsAllowed === 0) && (
+            <p className={styles.bodyLong01}>
+              <span className={styles.label01}>{t('refills', 'Refills').toUpperCase()}</span>{' '}
+              <span className={styles.refills}>{refillsAllowed}</span>
+            </p>
+          )}
+          {dosageInstruction?.text && <p className={styles.bodyLong01}>{dosageInstruction.text}</p>}
+          {dosageInstruction?.additionalInstruction?.length > 0 && (
+            <p className={styles.bodyLong01}>{dosageInstruction?.additionalInstruction[0].text}</p>
+          )}
+        </div>
+        {children}
       </div>
-      {children}
+      {footer && <div className={styles.footer}>{footer}</div>}
     </Tile>
   );
 };

--- a/src/components/medication-event.scss
+++ b/src/components/medication-event.scss
@@ -4,7 +4,7 @@
 
 .medicationEventTile {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   width: 100%;
   margin: layout.$spacing-01 0 layout.$spacing-03;
   padding: layout.$spacing-04 layout.$spacing-05 layout.$spacing-04 layout.$spacing-03;
@@ -17,10 +17,28 @@
     border-left: layout.$spacing-03 solid red;
   }
 
-  &.isTablet {
+  &.isTablet .content {
     flex-direction: column;
     gap: layout.$spacing-05;
   }
+}
+
+.content {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  gap: layout.$spacing-05;
+}
+
+.contentStart {
+  justify-content: flex-start;
+  column-gap: layout.$spacing-07;
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: layout.$spacing-05;
 }
 
 .medicationName {

--- a/src/components/medication-event.scss
+++ b/src/components/medication-event.scss
@@ -39,6 +39,10 @@
   display: flex;
   justify-content: flex-end;
   margin-top: layout.$spacing-05;
+
+  &:empty {
+    display: none;
+  }
 }
 
 .medicationName {

--- a/src/components/medication-event.test.tsx
+++ b/src/components/medication-event.test.tsx
@@ -210,4 +210,10 @@ describe('MedicationEvent', () => {
 
     expect(screen.getByRole('button', { name: 'Action Button' })).toBeInTheDocument();
   });
+
+  it('renders the footer content when provided', () => {
+    render(<MedicationEvent medicationEvent={baseMedicationRequest} footer={<button>Dispense</button>} />);
+
+    expect(screen.getByRole('button', { name: 'Dispense' })).toBeInTheDocument();
+  });
 });

--- a/src/prescriptions/prescription-details.component.tsx
+++ b/src/prescriptions/prescription-details.component.tsx
@@ -2,7 +2,13 @@ import React from 'react';
 import { SkeletonText, Tag, Tile } from '@carbon/react';
 import { WarningFilled } from '@carbon/react/icons';
 import { useTranslation } from 'react-i18next';
-import { ExtensionSlot, getAssignedExtensions, type PatientUuid, useConfig, UserHasAccess } from '@openmrs/esm-framework';
+import {
+  ExtensionSlot,
+  getAssignedExtensions,
+  type PatientUuid,
+  useConfig,
+  UserHasAccess,
+} from '@openmrs/esm-framework';
 import {
   computeMedicationRequestCombinedStatus,
   getConceptCodingDisplay,
@@ -163,9 +169,7 @@ const PrescriptionDetails: React.FC<{
                 status={generateStatusTag(bundle)}
                 alignContentStart
                 footer={actionButtons}>
-                {drugUuid && (
-                  <ExtensionSlot name="dispensing-prescription-side-effects-slot" state={{ drugUuid }} />
-                )}
+                {drugUuid && <ExtensionSlot name="dispensing-prescription-side-effects-slot" state={{ drugUuid }} />}
               </MedicationEvent>
             ) : (
               <MedicationEvent

--- a/src/prescriptions/prescription-details.component.tsx
+++ b/src/prescriptions/prescription-details.component.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import { SkeletonText, Tag, Tile } from '@carbon/react';
 import { WarningFilled } from '@carbon/react/icons';
 import { useTranslation } from 'react-i18next';
-import { type PatientUuid, useConfig, UserHasAccess } from '@openmrs/esm-framework';
+import { ExtensionSlot, type PatientUuid, useConfig, UserHasAccess } from '@openmrs/esm-framework';
 import {
   computeMedicationRequestCombinedStatus,
   getConceptCodingDisplay,
+  getUuidFromReference,
   useStaleEncounterUuids,
   getMostRecentMedicationDispenseStatus,
 } from '../utils';
@@ -145,15 +146,22 @@ const PrescriptionDetails: React.FC<{
             <MedicationEvent
               key={bundle.request.id}
               medicationEvent={bundle.request}
-              status={generateStatusTag(bundle)}>
-              <UserHasAccess privilege={PRIVILEGE_CREATE_DISPENSE}>
-                <ActionButtons
-                  patientUuid={patientUuid}
-                  encounterUuid={encounterUuid}
-                  medicationRequestBundle={bundle}
-                  disabled={staleEncounterUuids.includes(encounterUuid)}
-                />
-              </UserHasAccess>
+              status={generateStatusTag(bundle)}
+              alignContentStart
+              footer={
+                <UserHasAccess privilege={PRIVILEGE_CREATE_DISPENSE}>
+                  <ActionButtons
+                    patientUuid={patientUuid}
+                    encounterUuid={encounterUuid}
+                    medicationRequestBundle={bundle}
+                    disabled={staleEncounterUuids.includes(encounterUuid)}
+                  />
+                </UserHasAccess>
+              }>
+              <ExtensionSlot
+                name="dispensing-prescription-side-effects-slot"
+                state={{ drugUuid: getUuidFromReference(bundle.request.medicationReference?.reference) }}
+              />
             </MedicationEvent>
           ))
         ) : (

--- a/src/prescriptions/prescription-details.component.tsx
+++ b/src/prescriptions/prescription-details.component.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { SkeletonText, Tag, Tile } from '@carbon/react';
 import { WarningFilled } from '@carbon/react/icons';
 import { useTranslation } from 'react-i18next';
-import { ExtensionSlot, type PatientUuid, useConfig, UserHasAccess } from '@openmrs/esm-framework';
+import { ExtensionSlot, getAssignedExtensions, type PatientUuid, useConfig, UserHasAccess } from '@openmrs/esm-framework';
 import {
   computeMedicationRequestCombinedStatus,
   getConceptCodingDisplay,
@@ -38,6 +38,7 @@ const PrescriptionDetails: React.FC<{
   } = usePatientAllergies(patientUuid, config.refreshInterval);
   const { medicationRequestBundles, error, isLoading } = usePrescriptionDetails(encounterUuid, config.refreshInterval);
   const { staleEncounterUuids } = useStaleEncounterUuids();
+  const sideEffectsSlotFilled = getAssignedExtensions('dispensing-prescription-side-effects-slot').length > 0;
 
   const generateStatusTag = (medicationRequestBundle: MedicationRequestBundle): React.ReactNode => {
     const combinedStatus: MedicationRequestCombinedStatus = computeMedicationRequestCombinedStatus(
@@ -142,28 +143,39 @@ const PrescriptionDetails: React.FC<{
       )}
       {medicationRequestBundles &&
         (medicationRequestBundles.length > 0 ? (
-          medicationRequestBundles.map((bundle) => (
-            <MedicationEvent
-              key={bundle.request.id}
-              medicationEvent={bundle.request}
-              status={generateStatusTag(bundle)}
-              alignContentStart
-              footer={
-                <UserHasAccess privilege={PRIVILEGE_CREATE_DISPENSE}>
-                  <ActionButtons
-                    patientUuid={patientUuid}
-                    encounterUuid={encounterUuid}
-                    medicationRequestBundle={bundle}
-                    disabled={staleEncounterUuids.includes(encounterUuid)}
-                  />
-                </UserHasAccess>
-              }>
-              <ExtensionSlot
-                name="dispensing-prescription-side-effects-slot"
-                state={{ drugUuid: getUuidFromReference(bundle.request.medicationReference?.reference) }}
-              />
-            </MedicationEvent>
-          ))
+          medicationRequestBundles.map((bundle) => {
+            const drugUuid = getUuidFromReference(bundle.request.medicationReference?.reference);
+            const actionButtons = (
+              <UserHasAccess privilege={PRIVILEGE_CREATE_DISPENSE}>
+                <ActionButtons
+                  patientUuid={patientUuid}
+                  encounterUuid={encounterUuid}
+                  medicationRequestBundle={bundle}
+                  disabled={staleEncounterUuids.includes(encounterUuid)}
+                />
+              </UserHasAccess>
+            );
+
+            return sideEffectsSlotFilled ? (
+              <MedicationEvent
+                key={bundle.request.id}
+                medicationEvent={bundle.request}
+                status={generateStatusTag(bundle)}
+                alignContentStart
+                footer={actionButtons}>
+                {drugUuid && (
+                  <ExtensionSlot name="dispensing-prescription-side-effects-slot" state={{ drugUuid }} />
+                )}
+              </MedicationEvent>
+            ) : (
+              <MedicationEvent
+                key={bundle.request.id}
+                medicationEvent={bundle.request}
+                status={generateStatusTag(bundle)}>
+                {actionButtons}
+              </MedicationEvent>
+            );
+          })
         ) : (
           <p className={styles.emptyState}>{t('noPrescriptionsFound', 'No prescriptions found')}</p>
         ))}

--- a/src/prescriptions/prescription-details.test.tsx
+++ b/src/prescriptions/prescription-details.test.tsx
@@ -1,12 +1,19 @@
 import React from 'react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { useConfig } from '@openmrs/esm-framework';
+import { ExtensionSlot, getAssignedExtensions, useConfig } from '@openmrs/esm-framework';
 import { usePrescriptionDetails, usePatientAllergies } from '../medication-request/medication-request.resource';
 import { useStaleEncounterUuids } from '../utils';
 import type * as Utils from '../utils';
+import { type MedicationRequest, type MedicationRequestBundle, MedicationRequestStatus } from '../types';
 import PrescriptionDetails from './prescription-details.component';
 
+vi.mock('@openmrs/esm-framework', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@openmrs/esm-framework')>()),
+  getAssignedExtensions: vi.fn(() => []),
+}));
+vi.mock('../components/action-buttons.component', () => ({ default: () => null }));
+vi.mock('./prescription-actions.component', () => ({ default: () => null }));
 vi.mock('../medication-request/medication-request.resource');
 vi.mock('../utils', async (importOriginal) => {
   const actual = await importOriginal<typeof Utils>();
@@ -20,9 +27,31 @@ const mockUseConfig = vi.mocked(useConfig);
 const mockUsePrescriptionDetails = vi.mocked(usePrescriptionDetails);
 const mockUsePatientAllergies = vi.mocked(usePatientAllergies);
 const mockUseStaleEncounterUuids = vi.mocked(useStaleEncounterUuids);
+const mockExtensionSlot = vi.mocked(ExtensionSlot);
+const mockGetAssignedExtensions = vi.mocked(getAssignedExtensions);
 
 const mockEncounterUuid = 'test-encounter-uuid';
 const mockPatientUuid = 'test-patient-uuid';
+
+function buildRequest(overrides?: Partial<MedicationRequest>): MedicationRequest {
+  return {
+    resourceType: 'MedicationRequest',
+    id: 'request-1',
+    meta: { lastUpdated: '2023-01-24T19:02:04.000-05:00' },
+    status: MedicationRequestStatus.active,
+    intent: 'order',
+    priority: 'routine',
+    medicationReference: {
+      reference: 'Medication/drug-uuid-1',
+      type: 'Medication',
+      display: 'Paracetamol 500mg tablet',
+    },
+    subject: { reference: 'Patient/test-patient-id', type: 'Patient', display: 'Test Patient' },
+    dosageInstruction: [{ text: 'Take one tablet twice daily' }],
+    dispenseRequest: { validityPeriod: { start: '2023-01-24T19:02:04.000-05:00' } },
+    ...overrides,
+  } as MedicationRequest;
+}
 
 describe('PrescriptionDetails', () => {
   beforeEach(() => {
@@ -37,6 +66,7 @@ describe('PrescriptionDetails', () => {
     mockUseStaleEncounterUuids.mockReturnValue({
       staleEncounterUuids: [],
     });
+    mockGetAssignedExtensions.mockReturnValue([]);
   });
 
   describe('Allergies Display', () => {
@@ -267,6 +297,84 @@ describe('PrescriptionDetails', () => {
       render(<PrescriptionDetails encounterUuid={mockEncounterUuid} patientUuid={mockPatientUuid} />);
 
       expect(screen.getByText(/no prescriptions found/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('Side effects extension slot', () => {
+    beforeEach(() => {
+      mockExtensionSlot.mockClear();
+      mockGetAssignedExtensions.mockReturnValue([{ name: 'medication-side-effects-panel-dispensing' }] as any);
+      mockUsePatientAllergies.mockReturnValue({
+        allergies: [],
+        totalAllergies: 0,
+        error: undefined,
+        isLoading: false,
+      });
+    });
+
+    it('mounts the side effects slot with the drug uuid parsed from the medication reference', () => {
+      const bundle: MedicationRequestBundle = { request: buildRequest(), dispenses: [] };
+      mockUsePrescriptionDetails.mockReturnValue({
+        medicationRequestBundles: [bundle],
+        prescriptionDate: new Date(),
+        error: undefined,
+        isLoading: false,
+        mutate: vi.fn(),
+        isValidating: false,
+      });
+
+      render(<PrescriptionDetails encounterUuid={mockEncounterUuid} patientUuid={mockPatientUuid} />);
+
+      const slotCall = mockExtensionSlot.mock.calls.find(
+        (call) => call[0].name === 'dispensing-prescription-side-effects-slot',
+      );
+      expect(slotCall).toBeTruthy();
+      expect(slotCall?.[0].state).toEqual({ drugUuid: 'drug-uuid-1' });
+    });
+
+    it('does not mount the side effects slot for a request without a medication reference', () => {
+      const bundle: MedicationRequestBundle = {
+        request: buildRequest({
+          medicationReference: undefined,
+          medicationCodeableConcept: { coding: [{ code: '123', display: 'Paracetamol' }], text: 'Paracetamol' },
+        } as Partial<MedicationRequest>),
+        dispenses: [],
+      };
+      mockUsePrescriptionDetails.mockReturnValue({
+        medicationRequestBundles: [bundle],
+        prescriptionDate: new Date(),
+        error: undefined,
+        isLoading: false,
+        mutate: vi.fn(),
+        isValidating: false,
+      });
+
+      render(<PrescriptionDetails encounterUuid={mockEncounterUuid} patientUuid={mockPatientUuid} />);
+
+      const slotCall = mockExtensionSlot.mock.calls.find(
+        (call) => call[0].name === 'dispensing-prescription-side-effects-slot',
+      );
+      expect(slotCall).toBeUndefined();
+    });
+
+    it('does not mount the side effects slot when no extension is assigned to it', () => {
+      mockGetAssignedExtensions.mockReturnValue([]);
+      const bundle: MedicationRequestBundle = { request: buildRequest(), dispenses: [] };
+      mockUsePrescriptionDetails.mockReturnValue({
+        medicationRequestBundles: [bundle],
+        prescriptionDate: new Date(),
+        error: undefined,
+        isLoading: false,
+        mutate: vi.fn(),
+        isValidating: false,
+      });
+
+      render(<PrescriptionDetails encounterUuid={mockEncounterUuid} patientUuid={mockPatientUuid} />);
+
+      const slotCall = mockExtensionSlot.mock.calls.find(
+        (call) => call[0].name === 'dispensing-prescription-side-effects-slot',
+      );
+      expect(slotCall).toBeUndefined();
     });
   });
 });

--- a/src/prescriptions/prescription-details.test.tsx
+++ b/src/prescriptions/prescription-details.test.tsx
@@ -4,12 +4,13 @@ import { render, screen } from '@testing-library/react';
 import { ExtensionSlot, getAssignedExtensions, useConfig } from '@openmrs/esm-framework';
 import { usePrescriptionDetails, usePatientAllergies } from '../medication-request/medication-request.resource';
 import { useStaleEncounterUuids } from '../utils';
+import type * as EsmFramework from '@openmrs/esm-framework';
 import type * as Utils from '../utils';
 import { type MedicationRequest, type MedicationRequestBundle, MedicationRequestStatus } from '../types';
 import PrescriptionDetails from './prescription-details.component';
 
 vi.mock('@openmrs/esm-framework', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@openmrs/esm-framework')>()),
+  ...(await importOriginal<typeof EsmFramework>()),
   getAssignedExtensions: vi.fn(() => []),
 }));
 vi.mock('../components/action-buttons.component', () => ({ default: () => null }));
@@ -337,7 +338,7 @@ describe('PrescriptionDetails', () => {
         request: buildRequest({
           medicationReference: undefined,
           medicationCodeableConcept: { coding: [{ code: '123', display: 'Paracetamol' }], text: 'Paracetamol' },
-        } as Partial<MedicationRequest>),
+        }),
         dispenses: [],
       };
       mockUsePrescriptionDetails.mockReturnValue({


### PR DESCRIPTION
## Requirements

 - [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
 - [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
 - [x] My work includes tests or is validated by existing tests.

## Summary

Mounts a `dispensing-prescription-side-effects-slot` on the prescription details tile, guarded on the drug uuid parsed from the request's `medicationReference`, so the `openmrs-esm-medication-side-effects` microfrontend can render its panel per prescribed drug. 

## Screenshots

<img width="1870" height="670" alt="image" src="https://github.com/user-attachments/assets/387f7d33-f30d-465c-a4e4-bc0a3a371cee" />

## Related Issue

  https://openmrs.atlassian.net/browse/O3-5907

## Other

  Related PRs:
  * https://github.com/openmrs/openmrs-esm-medication-side-effects/pull/1
  * https://github.com/openmrs/openmrs-esm-patient-chart/pull/3591       
  * https://github.com/openmrs/openmrs-module-medicationsideeffects/pull/1
  * https://github.com/mekomsolutions/openmrs-module-initializer/pull/333
  * https://github.com/openmrs/openmrs-content-referenceapplication-demo/pull/85
