### PR TITLE
(feat) O3-5942: Sort renewed prescriptions using the latest MedicationRequest authored date

### DIFF
--- a/src/medication-request/medication-request.resource.test.tsx
+++ b/src/medication-request/medication-request.resource.test.tsx
@@ -4,6 +4,7 @@ import dayjs from 'dayjs';
 import useSWR from 'swr';
 import {
   updateMedicationRequestFulfillerStatus,
+  getPrescriptionRowDate,
   useMedicationRequest,
   usePatientAllergies,
   usePrescriptionDetails,
@@ -11,6 +12,7 @@ import {
 } from './medication-request.resource';
 import { openmrsFetch, parseDate } from '@openmrs/esm-framework';
 import { MedicationRequestFulfillerStatus } from '../types';
+import type { Encounter, MedicationRequest } from '../types';
 import { JSON_MERGE_PATH_MIME_TYPE, OPENMRS_FHIR_EXT_REQUEST_FULFILLER_STATUS } from '../constants';
 
 vi.mocked(openmrsFetch);
@@ -24,6 +26,23 @@ vi.mock('react', async (importOriginal) => {
 });
 
 describe('Medication Request Resource Test', () => {
+  test('uses the newest MedicationRequest authoredOn as the prescription table row date', () => {
+    const encounter = { period: { start: '2023-01-01T08:00:00Z' } } as Encounter;
+    const medicationRequests = [
+      { authoredOn: '2023-01-01T08:00:00Z' },
+      { authoredOn: '2023-02-15T10:30:00Z' },
+      { authoredOn: '2023-01-20T09:00:00Z' },
+    ] as Array<MedicationRequest>;
+
+    expect(getPrescriptionRowDate(encounter, medicationRequests)).toBe('2023-02-15T10:30:00Z');
+  });
+
+  test('uses the encounter start as the prescription table row date when authoredOn is unavailable', () => {
+    const encounter = { period: { start: '2023-01-01T08:00:00Z' } } as Encounter;
+
+    expect(getPrescriptionRowDate(encounter, [{} as MedicationRequest])).toBe('2023-01-01T08:00:00Z');
+  });
+
   test('usePrescriptionsTable should call active endpoint and proper date based on expiration period if status parameter is active', () => {
     // @ts-ignore
     useSWR.mockImplementation(() => ({ data: { data: 'mockedReturnData' } }));

--- a/src/medication-request/medication-request.resource.tsx
+++ b/src/medication-request/medication-request.resource.tsx
@@ -106,7 +106,7 @@ function buildPrescriptionsTableRow(
 ): PrescriptionsTableRow {
   return {
     id: encounter?.id,
-    created: encounter?.period?.start,
+    created: getPrescriptionRowDate(encounter, medicationRequests),
     patient: {
       name: encounter?.subject?.display,
       uuid: encounter?.subject?.reference?.split('/')[1],
@@ -126,6 +126,16 @@ function buildPrescriptionsTableRow(
     status: computePrescriptionStatusMessageCode(medicationRequests, medicationRequestExpirationPeriodInDays),
     location: encounter?.location ? encounter?.location[0]?.location.display : null,
   };
+}
+
+export function getPrescriptionRowDate(encounter: Encounter, medicationRequests: Array<MedicationRequest>): string {
+  const newestAuthoredOn = medicationRequests
+    .map((medicationRequest) => medicationRequest.authoredOn)
+    .filter((authoredOn): authoredOn is string => Boolean(authoredOn) && dayjs(authoredOn).isValid())
+    .sort((a, b) => dayjs(b).valueOf() - dayjs(a).valueOf())[0];
+
+  // Older MedicationRequests may not have authoredOn, so retain the encounter date as a fallback.
+  return newestAuthoredOn ?? encounter?.period?.start;
 }
 
 export function usePrescriptionDetails(encounterUuid: string, refreshInterval = null) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
**Problem**
The Search, Active Prescriptions, and All Prescriptions tables used Encounter.period.start as the prescription created date and sort value.

When a medication is renewed within an existing encounter, OpenMRS creates a new MedicationRequest with a new authoredOn date. Because the tables still referenced the original encounter date, renewed prescriptions displayed an outdated date and could be sorted below older prescriptions.

**Change**
Updated the prescription tables to use MedicationRequest.authoredOn as the created date and sorting value.

## Screenshots
https://github.com/user-attachments/assets/d9f99149-1490-4a15-8769-1e9abf6d14ce


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
